### PR TITLE
Add Universal Dragon ecosystem map and truth boundary

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,43 @@
+# Universal Dragon Ecosystem
+
+Creator: Aslam
+Project Identity: Universal Dragon
+Core Brain Direction: NOVA / NovaKutty
+Assistant and Builder Layer: EVE
+Operating Layer Direction: UDOS
+Quantum Language Direction: QBIT NOVA / QBIT NOVA C
+
+## Source of Truth
+
+Universal-Dragon-Core is the main ecosystem source of truth.
+
+Universal Dragon should not be treated as random separate repositories. Each repo has one clear role: core, support, public site, experiment, archive, or third-party reference.
+
+## Main Architecture
+
+| Layer | Repository | Role |
+|---|---|---|
+| Main Core | Universal-Dragon-Core | QBIT NOVA / .ud language direction, ecosystem control, docs, safe workflows |
+| C Runtime | qbit-nova-c | C-based quantum-style runtime, bytecode VM, state-vector simulator, virtual QCPU, OpenQASM bridge |
+| Public Proof | UniverseDragon14.github.io | Public portfolio, proof pages, project identity |
+| NOVA Guardian | nova-intelligence-core | Approval-first safety, backup, rollback, diagnostic planning |
+| Backend | nova-agi-core-backend | Safe backend direction for NOVA services |
+| EVE Builder | eve-app-builder | App/web builder workflow: discuss, plan, approve, build, test |
+| UDOS | Dragon-OS-Core / udos-site | Assistant-first operating/control layer concept |
+| Studio | studio-site | Creator tools and public roadmap |
+| Vision | universal-dragon-eye | Safe camera, OpenCV, local vision, robotics perception foundation |
+| Workflow Identity | Askutty | Aslam + NovaKutty approval-first workflow identity |
+
+## Build Rule
+
+doctor -> backup -> patch -> test -> approval -> deploy -> rollback ready
+
+## Truth Rule
+
+Universal Dragon must stay real, safe, legal, and useful.
+
+No fake proof.
+No physical quantum hardware claims.
+No harmful hacking claims.
+No private tracking or hidden surveillance direction.
+No public secrets.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -1,0 +1,48 @@
+# Universal Dragon Repo Map
+
+## Canonical Repos
+
+| Repo | Role | Status |
+|---|---|---|
+| Universal-Dragon-Core | Main ecosystem source of truth | MAIN |
+| qbit-nova-c | C runtime, virtual QCPU, OpenQASM bridge | SUPPORT / CORE RUNTIME |
+| UniverseDragon14.github.io | Public site and portfolio proof | PUBLIC SITE |
+| nova-intelligence-core | NOVA Guardian safety workflow | SUPPORT |
+| nova-agi-core-backend | Backend API/service direction | SUPPORT |
+| eve-app-builder | App builder workflow | SUPPORT |
+| Dragon-OS-Core | UDOS foundation | SUPPORT |
+| udos-site | UDOS public site | SUPPORT / PUBLIC SITE |
+| studio-site | Creator studio roadmap | SUPPORT / PUBLIC SITE |
+| universal-dragon-eye | Vision and perception foundation | SUPPORT WITH SAFETY BOUNDARY |
+| Askutty | Approval-first workflow identity | SUPPORT |
+
+## Duplicate / Fold Later
+
+These repos may be folded into the canonical structure or archived later after review:
+
+- Universal-dragon
+- universaldragon
+- Univercial-Dragon
+- universe-dragon-core
+- universal-dragon-site
+- universal-dragon-singularity
+
+No immediate delete.
+
+## Third-Party / External Reference Repos
+
+These should not be branded as Universal Dragon core work:
+
+- Magisk
+- three.js
+- v86
+- terminal
+- clerk-docs
+- intellij-sdk-docs
+- upload-artifact
+- earth-globe-threejs
+- bing-cn-mcp-server
+- angular
+- com.tachibana.downloader-1.2
+
+They may be kept as references or forks, but they should not confuse the public Universal Dragon identity.

--- a/docs/TRUTH_BOUNDARY.md
+++ b/docs/TRUTH_BOUNDARY.md
@@ -1,0 +1,56 @@
+# Universal Dragon Truth Boundary
+
+## Quantum Boundary
+
+QBIT NOVA C is a C-based quantum-style language runtime, bytecode VM, state-vector simulator, virtual QCPU layer, and OpenQASM bridge.
+
+It runs on classical hardware such as Raspberry Pi 5.
+
+It does not claim that a phone, laptop, or Raspberry Pi becomes a physical quantum chip.
+
+Allowed wording:
+- software virtual QCPU
+- state-vector simulator
+- C-based quantum-style language runtime
+- OpenQASM bridge
+- classical hardware support
+
+Blocked wording:
+- physical quantum computer
+- real quantum chip created by Pi
+- phone became quantum hardware
+- hardware quantum processor generated in software
+
+## Cybersecurity Boundary
+
+Allowed direction:
+- defensive diagnostics
+- secret scanning
+- access control
+- logs
+- safe recovery
+- backup and rollback
+- read-only system maps
+- approval-based repair
+- local lab learning
+
+Blocked direction:
+- account breaking
+- stealing data
+- malware
+- silent persistence
+- bypassing real systems
+- private-person tracking
+- locate-by-photo workflows
+- hidden surveillance
+- unrestricted public terminal access
+
+## Vision Boundary
+
+universal-dragon-eye may support own-device camera experiments, OpenCV tests, object/scene understanding, dashboards, and robot perception.
+
+It must not support tracking private people, locating people by photo, phone-number tracking, social-media targeting, stealth surveillance, or private camera feed publishing.
+
+## Public Repository Boundary
+
+Public repositories must not contain API keys, .env values, Cloudflare tunnel credentials, private IPs, live logs, private camera feeds, private uploads, or device credentials.


### PR DESCRIPTION
## Summary

Adds canonical Universal Dragon ecosystem documentation.

Files added:
- `ECOSYSTEM.md`
- `docs/REPO_MAP.md`
- `docs/TRUTH_BOUNDARY.md`

## Purpose

Locks the Universal Dragon ecosystem structure, source-of-truth repo, safety boundary, and public truth rules.

## Safety

Docs only.
No code changes.
No secrets.
No force push.
No history rewrite.
No repo deletion.

## Boundary

- `Universal-Dragon-Core` is the main source of truth.
- `qbit-nova-c` is the C-based QBIT NOVA runtime, virtual QCPU, state-vector simulator, and OpenQASM bridge.
- No physical quantum hardware claims.
- No unsafe security claims.
- No private tracking direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive ecosystem architecture documentation defining the project's organizational structure, directional layers, and repository classification system.
  * Added repository mapping documentation cataloging canonical repositories, duplicate entries, and third-party references with their respective roles and status.
  * Added truth boundary documentation establishing explicit constraints, safety guidelines, and acceptable claim parameters for quantum-themed and cybersecurity-focused development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->