### PR TITLE
Add QBIT NOVA Language development link to install page

### DIFF
--- a/docs/nova-install.html
+++ b/docs/nova-install.html
@@ -278,6 +278,24 @@ nova doctor</pre>
       </div>
     </div>
 
+    <section class="terminal" id="qbit-nova-language">
+      <div class="bar">QBIT NOVA LANGUAGE • ACTIVE DEVELOPMENT</div>
+      <div class="card" style="border: 0; border-radius: 0; background: transparent;">
+        <h3>🐉 Dedicated Language Project</h3>
+        <p>
+          QBIT NOVA Language is experimental, unfinished, and under active development.
+          The public repository currently contains the frozen C-implementation specification v0.1;
+          it does not yet provide a production compiler or runtime.
+        </p>
+        <p>
+          <a class="btn"
+             href="https://github.com/UniverseDragon14/qbit-nova-language"
+             target="_blank"
+             rel="noopener noreferrer">View Development Repository</a>
+        </p>
+      </div>
+    </section>
+
     <section class="terminal">
       <div class="bar">QBIT TEST OUTPUT</div>
       <pre>nova run "$PREFIX/share/nova/examples/qbit_test.qnova"


### PR DESCRIPTION
## What changed

- adds a visible **QBIT NOVA Language — Active Development** section to `docs/nova-install.html`
- links to the dedicated public repository: https://github.com/UniverseDragon14/qbit-nova-language
- states clearly that the project is experimental, unfinished, and does not yet provide a production compiler or runtime

## Why

The new dedicated language repository is now public. The install page should expose it without presenting the specification preview as an installable production runtime.

## Safety and impact

- existing NOVA installer commands are unchanged
- QBIT NOVA C is untouched
- only one HTML file is changed
- the link opens in a new tab with `noopener noreferrer`

## Validation

- remote branch content exactly matches the prepared change
- development label appears once
- repository URL appears once
- both existing installer command occurrences remain unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Active Development” section to the installation page.
  * Clarified that QBIT NOVA Language is experimental and unfinished.
  * Noted the frozen C implementation specification (v0.1) and added a link to the development repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->