### PR TITLE
feat: reuse OpenAI key for guarded voice profiles

### DIFF
--- a/.github/workflows/dragon-room-magic-v1.yml
+++ b/.github/workflows/dragon-room-magic-v1.yml
@@ -72,106 +72,16 @@ jobs:
           grep -q 'dragonAwaken' room-magic/termux/awaken.html
           grep -q '^ELEVENLABS_API_KEY=$' room-magic/elevenlabs.env.example
           grep -q '^ELEVENLABS_VOICE_ID=$' room-magic/elevenlabs.env.example
-          grep -q '^DRAGON_VOICE_ACCESS_TOKEN=          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
-          echo 'TERMUX_PORTABLE_ASSETS=PASS'
-
-      - name: Prove Termux handoff installer
-        shell: bash
-        run: |
-          set -euo pipefail
-          export HOME="$RUNNER_TEMP/dragon-home"
-          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
-          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
-          mkdir -p "$HOME"
-          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
-          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
-          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
-          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
-          echo 'TERMUX_HANDOFF_PROOF=PASS'
- room-magic/elevenlabs.env.example
-          grep -q '^DRAGON_VOICE_PROVIDER=local          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
-          echo 'TERMUX_PORTABLE_ASSETS=PASS'
-
-      - name: Prove Termux handoff installer
-        shell: bash
-        run: |
-          set -euo pipefail
-          export HOME="$RUNNER_TEMP/dragon-home"
-          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
-          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
-          mkdir -p "$HOME"
-          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
-          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
-          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
-          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
-          echo 'TERMUX_HANDOFF_PROOF=PASS'
- room-magic/openai.env.example
-          grep -q '^DRAGON_VOICE_ACCESS_TOKEN=          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
-          echo 'TERMUX_PORTABLE_ASSETS=PASS'
-
-      - name: Prove Termux handoff installer
-        shell: bash
-        run: |
-          set -euo pipefail
-          export HOME="$RUNNER_TEMP/dragon-home"
-          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
-          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
-          mkdir -p "$HOME"
-          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
-          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
-          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
-          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
-          echo 'TERMUX_HANDOFF_PROOF=PASS'
- room-magic/openai.env.example
-          grep -q '^OPENAI_TTS_MODEL=gpt-4o-mini-tts          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
-          echo 'TERMUX_PORTABLE_ASSETS=PASS'
-
-      - name: Prove Termux handoff installer
-        shell: bash
-        run: |
-          set -euo pipefail
-          export HOME="$RUNNER_TEMP/dragon-home"
-          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
-          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
-          mkdir -p "$HOME"
-          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
-          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
-          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
-          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
-          echo 'TERMUX_HANDOFF_PROOF=PASS'
- room-magic/openai.env.example
+          grep -q '^DRAGON_VOICE_ACCESS_TOKEN=$' room-magic/elevenlabs.env.example
+          grep -q '^DRAGON_VOICE_PROVIDER=local$' room-magic/openai.env.example
+          grep -q '^DRAGON_VOICE_ACCESS_TOKEN=$' room-magic/openai.env.example
+          grep -q '^OPENAI_TTS_MODEL=gpt-4o-mini-tts$' room-magic/openai.env.example
           grep -q 'authorizeVoiceRequest' server.ts
           grep -q 'voice_api_disabled' server.ts
           grep -q 'generateOpenAITtsSpeech' server.ts
           grep -q 'premium_voice_opt_in_required' server.ts
           grep -q 'reservePaidVoiceBudget' server.ts
-          grep -q '^data/dragon-voice-usage.json          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
-          echo 'TERMUX_PORTABLE_ASSETS=PASS'
-
-      - name: Prove Termux handoff installer
-        shell: bash
-        run: |
-          set -euo pipefail
-          export HOME="$RUNNER_TEMP/dragon-home"
-          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
-          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
-          mkdir -p "$HOME"
-          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
-          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
-          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
-          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
-          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
-          echo 'TERMUX_HANDOFF_PROOF=PASS'
- .gitignore
+          grep -q '^data/dragon-voice-usage.json$' .gitignore
           grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
           echo 'TERMUX_PORTABLE_ASSETS=PASS'
 

--- a/.github/workflows/dragon-room-magic-v1.yml
+++ b/.github/workflows/dragon-room-magic-v1.yml
@@ -17,6 +17,7 @@ on:
       - 'src/voice/**'
       - 'room-magic/**'
       - 'tools/proof_voice_soul.ts'
+      - 'tools/proof_voice_gateway.ts'
       - '.github/workflows/dragon-room-magic-v1.yml'
 
 permissions:
@@ -45,7 +46,10 @@ jobs:
         run: npm run lint
 
       - name: Voice Soul deterministic proof
-        run: npx tsx tools/proof_voice_soul.ts
+        run: npx --no-install tsx tools/proof_voice_soul.ts
+
+      - name: Guarded voice gateway proof
+        run: npx --no-install tsx tools/proof_voice_gateway.ts
 
       - name: Production build
         run: npm run build
@@ -59,6 +63,7 @@ jobs:
           test -s room-magic/termux/voice-eleven-v3.sh
           test -s room-magic/termux/install-v1.sh
           test -s room-magic/elevenlabs.env.example
+          test -s room-magic/openai.env.example
           bash -n room-magic/termux/awaken-v3.sh
           bash -n room-magic/termux/voice-eleven-v3.sh
           bash -n room-magic/termux/install-v1.sh
@@ -67,9 +72,106 @@ jobs:
           grep -q 'dragonAwaken' room-magic/termux/awaken.html
           grep -q '^ELEVENLABS_API_KEY=$' room-magic/elevenlabs.env.example
           grep -q '^ELEVENLABS_VOICE_ID=$' room-magic/elevenlabs.env.example
-          grep -q '^DRAGON_VOICE_ACCESS_TOKEN=$' room-magic/elevenlabs.env.example
+          grep -q '^DRAGON_VOICE_ACCESS_TOKEN=          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
+          echo 'TERMUX_PORTABLE_ASSETS=PASS'
+
+      - name: Prove Termux handoff installer
+        shell: bash
+        run: |
+          set -euo pipefail
+          export HOME="$RUNNER_TEMP/dragon-home"
+          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
+          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
+          mkdir -p "$HOME"
+          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
+          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
+          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
+          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
+          echo 'TERMUX_HANDOFF_PROOF=PASS'
+ room-magic/elevenlabs.env.example
+          grep -q '^DRAGON_VOICE_PROVIDER=local          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
+          echo 'TERMUX_PORTABLE_ASSETS=PASS'
+
+      - name: Prove Termux handoff installer
+        shell: bash
+        run: |
+          set -euo pipefail
+          export HOME="$RUNNER_TEMP/dragon-home"
+          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
+          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
+          mkdir -p "$HOME"
+          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
+          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
+          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
+          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
+          echo 'TERMUX_HANDOFF_PROOF=PASS'
+ room-magic/openai.env.example
+          grep -q '^DRAGON_VOICE_ACCESS_TOKEN=          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
+          echo 'TERMUX_PORTABLE_ASSETS=PASS'
+
+      - name: Prove Termux handoff installer
+        shell: bash
+        run: |
+          set -euo pipefail
+          export HOME="$RUNNER_TEMP/dragon-home"
+          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
+          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
+          mkdir -p "$HOME"
+          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
+          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
+          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
+          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
+          echo 'TERMUX_HANDOFF_PROOF=PASS'
+ room-magic/openai.env.example
+          grep -q '^OPENAI_TTS_MODEL=gpt-4o-mini-tts          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
+          echo 'TERMUX_PORTABLE_ASSETS=PASS'
+
+      - name: Prove Termux handoff installer
+        shell: bash
+        run: |
+          set -euo pipefail
+          export HOME="$RUNNER_TEMP/dragon-home"
+          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
+          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
+          mkdir -p "$HOME"
+          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
+          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
+          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
+          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
+          echo 'TERMUX_HANDOFF_PROOF=PASS'
+ room-magic/openai.env.example
           grep -q 'authorizeVoiceRequest' server.ts
           grep -q 'voice_api_disabled' server.ts
+          grep -q 'generateOpenAITtsSpeech' server.ts
+          grep -q 'premium_voice_opt_in_required' server.ts
+          grep -q 'reservePaidVoiceBudget' server.ts
+          grep -q '^data/dragon-voice-usage.json          grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
+          echo 'TERMUX_PORTABLE_ASSETS=PASS'
+
+      - name: Prove Termux handoff installer
+        shell: bash
+        run: |
+          set -euo pipefail
+          export HOME="$RUNNER_TEMP/dragon-home"
+          export DRAGON_ROOM_MAGIC_HOME="$RUNNER_TEMP/dragon-target"
+          export DRAGON_ROOM_MAGIC_BACKUPS="$RUNNER_TEMP/dragon-backups"
+          mkdir -p "$HOME"
+          bash room-magic/termux/install-v1.sh | tee "$RUNNER_TEMP/install-proof.log"
+          grep -q '^SECRET_FILES_TOUCHED=NO$' "$RUNNER_TEMP/install-proof.log"
+          grep -q '^ROOM_MAGIC_HANDOFF_INSTALL=PASS$' "$RUNNER_TEMP/install-proof.log"
+          test -s "$DRAGON_ROOM_MAGIC_HOME/awaken.html"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/awaken-v3.sh"
+          test -x "$DRAGON_ROOM_MAGIC_HOME/voice-eleven-v3.sh"
+          echo 'TERMUX_HANDOFF_PROOF=PASS'
+ .gitignore
           grep -q -- '--directory "$WEB_ROOT"' room-magic/termux/awaken-v3.sh
           echo 'TERMUX_PORTABLE_ASSETS=PASS'
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 .idea/
 .tmp/
 dist/
+
+# Runtime voice budget state
+data/dragon-voice-usage.json

--- a/room-magic/README.md
+++ b/room-magic/README.md
@@ -77,33 +77,85 @@ If the expressive provider is not configured, `VOICE_PATH=ANDROID_TTS_FALLBACK` 
 
 ## Protected server-side voice contract
 
-The server runtime needs all four variables before the billable endpoint is enabled:
+The already-configured Pi5 `OPENAI_API_KEY` remains only in the server runtime environment. This repository, the status endpoints, and application logs never list, copy, return, or print its value.
+
+### Provider modes
+
+- `local` is the safe default. The protected endpoint returns a `202` client-TTS instruction and makes no paid provider request.
+- `openai` enables OpenAI Text-to-Speech only when the existing runtime key is available.
+- `elevenlabs` keeps the existing optional server-side ElevenLabs flow available.
+- A request body cannot select a provider; only the server environment can do that.
+
+Use `room-magic/openai.env.example` as a names-only template. Do not add real secrets to it or commit a populated `.env` file.
 
 ```text
-ELEVENLABS_API_KEY=<server secret>
-ELEVENLABS_VOICE_ID=<saved Arabella voice id>
-ELEVENLABS_MODEL=eleven_v3
+DRAGON_VOICE_PROVIDER=local
 DRAGON_VOICE_ACCESS_TOKEN=<separate strong bearer token>
+OPENAI_TTS_MODEL=gpt-4o-mini-tts
+DRAGON_VOICE_DEFAULT_PROFILE=NOVA
+DRAGON_VOICE_MAX_INPUT_CHARS=400
+DRAGON_VOICE_DAILY_MAX_REQUESTS=6
+DRAGON_VOICE_DAILY_MAX_CHARACTERS=2400
+DRAGON_VOICE_USAGE_FILE=<optional local path>
 ```
 
-`POST /api/voice/speak` requires:
+When `DRAGON_VOICE_PROVIDER=openai`, the existing `OPENAI_API_KEY` must already be loaded by the service environment. It is intentionally not duplicated in this template.
+
+### Six built-in voice profiles
+
+| Profile | OpenAI built-in voice | Intended style |
+| --- | --- | --- |
+| `NOVA` | `marin` | warm, clear assistant |
+| `EVE` | `cedar` | friendly and confident |
+| `DRAGON` | `onyx` | deliberate and protective |
+| `ANANYA` | `coral` | bright and gentle |
+| `GUARDIAN` | `sage` | calm safety guidance |
+| `NARRATOR` | `alloy` | balanced storytelling |
+
+These are built-in provider voices only. This implementation does not train, clone, or upload anyone's voice.
+
+### Calling the protected endpoint
+
+`POST /api/voice/speak` always requires:
 
 ```text
 Authorization: Bearer <DRAGON_VOICE_ACCESS_TOKEN>
 ```
 
-Body:
+A paid provider additionally requires a strict per-request opt-in:
 
 ```json
 {
   "text": "Heey, Aslam... Dragon Resonance is active.",
   "mood": "PLAYFUL",
-  "context": "WAKE"
+  "context": "WAKE",
+  "voice_profile": "NOVA",
+  "premium": true
 }
 ```
 
-The server converts the provider-neutral Voice Soul plan into Eleven v3 prompt text and returns MP3 audio. Only one server-side voice generation is admitted at a time. The provider key, access token, and voice ID are never returned by `/api/voice/status` or `/api/health`.
+With `local`, the response is a `202` JSON instruction containing sanitized text for client-side/Android TTS. With `openai` or `elevenlabs`, omitting `"premium": true` returns `premium_voice_opt_in_required` and no billable request is made.
 
+Successful paid audio is MP3 and includes `X-Dragon-AI-Generated: true`. The playback UI must clearly disclose that the voice is AI-generated before the user hears it.
+
+### Cost and safety guard
+
+- The default limit is 400 input characters, 6 paid requests/day, and 2,400 paid characters/day.
+- Usage resets on the UTC date and is written to `data/dragon-voice-usage.json`, which is ignored by Git.
+- A paid request reserves its budget before contacting a provider. Provider failures are not rolled back, which intentionally favors cost safety.
+- Corrupt or unavailable usage-state storage fails closed with `voice_budget_state_unavailable`; it does not make a paid fallback request.
+- The JSON state file is designed for the single Pi5 service process. A future multi-instance deployment needs a shared atomic usage store.
+- Private reasoning tags and bracketed audio labels are removed by the Voice Soul planner before text is returned or sent to a provider.
+
+The existing ElevenLabs secret variables remain supported for the `elevenlabs` provider:
+
+```text
+ELEVENLABS_API_KEY=<server secret>
+ELEVENLABS_VOICE_ID=<saved provider voice id>
+ELEVENLABS_MODEL=eleven_v3
+```
+
+The provider key, bearer token, and voice ID are never returned by `/api/voice/status` or `/api/health`.
 ## Next integration gates
 
 1. Keep CI and automated review clean.

--- a/room-magic/openai.env.example
+++ b/room-magic/openai.env.example
@@ -1,0 +1,18 @@
+# Safe default: no paid provider call. The client performs local TTS.
+DRAGON_VOICE_PROVIDER=local
+
+# Required before /api/voice/speak is enabled. Keep this local-only and strong.
+DRAGON_VOICE_ACCESS_TOKEN=
+
+# OpenAI mode reuses the existing OPENAI_API_KEY already loaded by the server.
+# Do not paste any key into this example file.
+OPENAI_TTS_MODEL=gpt-4o-mini-tts
+DRAGON_VOICE_DEFAULT_PROFILE=NOVA
+
+# Paid speech protection: opt-in request, max 400 characters, 6 requests / 2400 chars per UTC day.
+DRAGON_VOICE_MAX_INPUT_CHARS=400
+DRAGON_VOICE_DAILY_MAX_REQUESTS=6
+DRAGON_VOICE_DAILY_MAX_CHARACTERS=2400
+
+# Optional local state location. Leave empty to use data/dragon-voice-usage.json.
+DRAGON_VOICE_USAGE_FILE=

--- a/server.ts
+++ b/server.ts
@@ -6,8 +6,22 @@ import mqtt from "mqtt";
 import path from "path";
 import { timingSafeEqual } from "crypto";
 import { fileURLToPath } from "url";
+import { mkdir, readFile, rename, writeFile } from "fs/promises";
 import { planVoiceSoul, type DragonContext, type DragonMood } from "./src/voice/voiceSoul";
 import { renderElevenV3Prompt } from "./src/voice/elevenV3";
+import {
+  buildOpenAITtsInstructions,
+  getDragonVoiceProfile,
+  listDragonVoiceProfiles,
+} from "./src/voice/openaiTts";
+import {
+  parsePositiveInteger,
+  reserveVoiceBudget,
+  resolveDragonVoiceProvider,
+  utcVoiceUsageDate,
+  type DragonVoiceProvider,
+  type VoiceBudgetLimits,
+} from "./src/voice/voiceBudget";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -26,6 +40,78 @@ For risky actions, give a plan and ask for explicit yes/no approval.`;
 const DRAGON_MOODS = new Set<DragonMood>(["CALM", "PLAYFUL", "CURIOUS", "SERIOUS", "WHISPER"]);
 const DRAGON_CONTEXTS = new Set<DragonContext>(["WAKE", "CHAT", "ALERT"]);
 let voiceRequestInFlight = false;
+
+function activeVoiceProvider(): DragonVoiceProvider {
+  return resolveDragonVoiceProvider(process.env.DRAGON_VOICE_PROVIDER);
+}
+
+function voiceProviderModel(provider: DragonVoiceProvider): string {
+  if (provider === "openai") return process.env.OPENAI_TTS_MODEL || "gpt-4o-mini-tts";
+  if (provider === "elevenlabs") return process.env.ELEVENLABS_MODEL || "eleven_v3";
+  return "local-client-tts";
+}
+
+function isVoiceProviderConfigured(provider: DragonVoiceProvider): boolean {
+  if (provider === "local") return true;
+  if (provider === "openai") return Boolean(process.env.OPENAI_API_KEY);
+  return Boolean(process.env.ELEVENLABS_API_KEY && process.env.ELEVENLABS_VOICE_ID);
+}
+
+function voiceBudgetLimits(): VoiceBudgetLimits {
+  return {
+    maxRequests: parsePositiveInteger(process.env.DRAGON_VOICE_DAILY_MAX_REQUESTS, 6),
+    maxCharacters: parsePositiveInteger(process.env.DRAGON_VOICE_DAILY_MAX_CHARACTERS, 2400),
+  };
+}
+
+function voiceMaxInputChars(): number {
+  return parsePositiveInteger(process.env.DRAGON_VOICE_MAX_INPUT_CHARS, 400);
+}
+
+function voiceUsageFile(): string {
+  return process.env.DRAGON_VOICE_USAGE_FILE
+    || path.join(process.cwd(), "data", "dragon-voice-usage.json");
+}
+
+async function reservePaidVoiceBudget(inputCharacters: number) {
+  const usageFile = voiceUsageFile();
+  const usageDate = utcVoiceUsageDate(new Date());
+  let current: unknown;
+
+  try {
+    const raw = await readFile(usageFile, "utf8");
+    current = JSON.parse(raw);
+  } catch (error: any) {
+    if (error?.code !== "ENOENT") {
+      throw new Error("voice_budget_state_unavailable");
+    }
+  }
+
+  if (current !== undefined && (
+    !current
+    || typeof current !== "object"
+    || Array.isArray(current)
+  )) {
+    throw new Error("voice_budget_state_unavailable");
+  }
+
+  const reservation = reserveVoiceBudget(current, voiceBudgetLimits(), inputCharacters, usageDate);
+  if (!reservation.allowed) return reservation;
+
+  try {
+    await mkdir(path.dirname(usageFile), { recursive: true });
+    const tempFile = usageFile + "." + process.pid + ".tmp";
+    await writeFile(tempFile, JSON.stringify(reservation.next) + "\n", {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(tempFile, usageFile);
+  } catch {
+    throw new Error("voice_budget_state_unavailable");
+  }
+
+  return reservation;
+}
 
 function safeTokenMatch(candidate: string, expected: string): boolean {
   if (!candidate || !expected) return false;
@@ -105,7 +191,7 @@ async function callOpenAICompatible(messages: ChatMessage[]) {
   };
 }
 
-async function generateElevenV3Speech(text: string, mood: DragonMood, context: DragonContext) {
+async function generateElevenV3Speech(plan: ReturnType<typeof planVoiceSoul>) {
   const apiKey = process.env.ELEVENLABS_API_KEY || "";
   const voiceId = process.env.ELEVENLABS_VOICE_ID || "";
   const model = process.env.ELEVENLABS_MODEL || "eleven_v3";
@@ -118,14 +204,13 @@ async function generateElevenV3Speech(text: string, mood: DragonMood, context: D
     };
   }
 
-  const plan = planVoiceSoul({ text, mood, context });
   const providerText = renderElevenV3Prompt(plan);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 45_000);
 
   try {
     const endpoint = new URL(
-      `https://api.elevenlabs.io/v1/text-to-speech/${encodeURIComponent(voiceId)}`,
+      "https://api.elevenlabs.io/v1/text-to-speech/" + encodeURIComponent(voiceId),
     );
     endpoint.searchParams.set("output_format", "mp3_44100_128");
 
@@ -144,8 +229,7 @@ async function generateElevenV3Speech(text: string, mood: DragonMood, context: D
     });
 
     if (!response.ok) {
-      const detail = (await response.text()).slice(0, 320);
-      throw new Error(`ElevenLabs error ${response.status}: ${detail}`);
+      throw new Error("ElevenLabs voice request failed with status " + response.status);
     }
 
     return {
@@ -155,6 +239,60 @@ async function generateElevenV3Speech(text: string, mood: DragonMood, context: D
       audio: Buffer.from(await response.arrayBuffer()),
       requestId: response.headers.get("request-id") || "",
       characterCost: response.headers.get("character-cost") || "",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function generateOpenAITtsSpeech(
+  plan: ReturnType<typeof planVoiceSoul>,
+  profile: ReturnType<typeof getDragonVoiceProfile>,
+) {
+  const apiKey = process.env.OPENAI_API_KEY || "";
+  const model = process.env.OPENAI_TTS_MODEL || "gpt-4o-mini-tts";
+
+  if (!apiKey) {
+    return {
+      ok: false as const,
+      reason: "voice_provider_not_configured",
+      model,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 45_000);
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/audio/speech", {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer " + apiKey,
+        "Content-Type": "application/json",
+        "Accept": "audio/mpeg",
+      },
+      body: JSON.stringify({
+        model,
+        voice: profile.openaiVoice,
+        input: plan.spokenText,
+        instructions: buildOpenAITtsInstructions(plan, profile),
+        response_format: "mp3",
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error("OpenAI voice request failed with status " + response.status);
+    }
+
+    return {
+      ok: true as const,
+      model,
+      plan,
+      profile,
+      audio: Buffer.from(await response.arrayBuffer()),
+      requestId: response.headers.get("x-request-id") || "",
+      characterCost: "",
     };
   } finally {
     clearTimeout(timeout);
@@ -211,35 +349,37 @@ async function startServer() {
   });
 
   app.get("/api/health", (req, res) => {
+    const provider = activeVoiceProvider();
     res.json({
       status: "ok",
       mqtt: mqttClient.connected,
       ai_provider: process.env.GROQ_API_KEY ? "groq" : process.env.OPENAI_API_KEY ? "openai" : "missing",
       model: process.env.GROQ_API_KEY ? (process.env.GROQ_MODEL || "openai/gpt-oss-120b") : (process.env.OPENAI_MODEL || "gpt-4.1-mini"),
       voice: {
-        provider: "elevenlabs",
-        configured: Boolean(
-          process.env.ELEVENLABS_API_KEY
-          && process.env.ELEVENLABS_VOICE_ID
-          && process.env.DRAGON_VOICE_ACCESS_TOKEN
-        ),
+        provider,
+        configured: Boolean(process.env.DRAGON_VOICE_ACCESS_TOKEN) && isVoiceProviderConfigured(provider),
         protected: true,
-        model: process.env.ELEVENLABS_MODEL || "eleven_v3",
+        model: voiceProviderModel(provider),
+        paid_provider: provider !== "local",
+        daily_limits: provider === "local" ? null : voiceBudgetLimits(),
       },
     });
   });
 
   app.get("/api/voice/status", (req, res) => {
+    const provider = activeVoiceProvider();
     res.json({
       ok: true,
-      provider: "elevenlabs",
-      configured: Boolean(
-        process.env.ELEVENLABS_API_KEY
-        && process.env.ELEVENLABS_VOICE_ID
-        && process.env.DRAGON_VOICE_ACCESS_TOKEN
-      ),
+      provider,
+      configured: Boolean(process.env.DRAGON_VOICE_ACCESS_TOKEN) && isVoiceProviderConfigured(provider),
       protected: true,
-      model: process.env.ELEVENLABS_MODEL || "eleven_v3",
+      model: voiceProviderModel(provider),
+      paid_provider: provider !== "local",
+      explicit_premium_opt_in_required: provider !== "local",
+      profiles: listDragonVoiceProfiles(),
+      default_profile: getDragonVoiceProfile(process.env.DRAGON_VOICE_DEFAULT_PROFILE).id,
+      max_input_chars: voiceMaxInputChars(),
+      daily_limits: provider === "local" ? null : voiceBudgetLimits(),
       voice_id_exposed: false,
     });
   });
@@ -263,36 +403,108 @@ async function startServer() {
     voiceRequestInFlight = true;
 
     try {
-      const text = String(req.body?.text || "").trim().slice(0, 1200);
+      const rawText = String(req.body?.text || "").trim();
+      const maxInputChars = voiceMaxInputChars();
       const requestedMood = String(req.body?.mood || "PLAYFUL").toUpperCase() as DragonMood;
       const requestedContext = String(req.body?.context || "CHAT").toUpperCase() as DragonContext;
 
-      if (!text) {
+      if (!rawText) {
         return res.status(400).json({ ok: false, error: "text_required" });
+      }
+
+      if (rawText.length > maxInputChars) {
+        return res.status(400).json({
+          ok: false,
+          error: "voice_input_too_long",
+          max_input_chars: maxInputChars,
+        });
       }
 
       const mood: DragonMood = DRAGON_MOODS.has(requestedMood) ? requestedMood : "CALM";
       const context: DragonContext = DRAGON_CONTEXTS.has(requestedContext) ? requestedContext : "CHAT";
-      const result = await generateElevenV3Speech(text, mood, context);
+      const plan = planVoiceSoul({ text: rawText, mood, context });
+
+      if (!plan.spokenText) {
+        return res.status(400).json({ ok: false, error: "voice_text_empty_after_sanitize" });
+      }
+
+      const requestedProfile = req.body?.voice_profile || req.body?.voiceProfile;
+      const profile = getDragonVoiceProfile(
+        typeof requestedProfile === "string"
+          ? requestedProfile
+          : process.env.DRAGON_VOICE_DEFAULT_PROFILE,
+      );
+      const provider = activeVoiceProvider();
+
+      if (provider === "local") {
+        return res.status(202).json({
+          ok: true,
+          action: "client_tts",
+          ai_generated: false,
+          provider: "local",
+          text: plan.spokenText,
+          mood: plan.mood,
+          profile: profile.id,
+        });
+      }
+
+      if (req.body?.premium !== true) {
+        return res.status(409).json({
+          ok: false,
+          error: "premium_voice_opt_in_required",
+          provider,
+        });
+      }
+
+      if (!isVoiceProviderConfigured(provider)) {
+        return res.status(503).json({
+          ok: false,
+          error: "voice_provider_not_configured",
+          provider,
+          model: voiceProviderModel(provider),
+        });
+      }
+
+      const budget = await reservePaidVoiceBudget(plan.spokenText.length);
+      if (!budget.allowed) {
+        return res.status(429).json({
+          ok: false,
+          error: budget.reason,
+          provider,
+          daily_usage: budget.next,
+          daily_limits: voiceBudgetLimits(),
+        });
+      }
+
+      const result = provider === "openai"
+        ? await generateOpenAITtsSpeech(plan, profile)
+        : await generateElevenV3Speech(plan);
 
       if (!result.ok) {
         return res.status(503).json({
           ok: false,
           error: result.reason,
-          provider: "elevenlabs",
+          provider,
           model: result.model,
         });
       }
 
       res.setHeader("Content-Type", "audio/mpeg");
       res.setHeader("Cache-Control", "no-store");
+      res.setHeader("X-Dragon-AI-Generated", "true");
+      res.setHeader("X-Dragon-Voice-Provider", provider);
+      res.setHeader("X-Dragon-Voice-Profile", profile.id);
       res.setHeader("X-Dragon-Voice-Mood", result.plan.mood);
       res.setHeader("X-Dragon-Voice-Model", result.model);
       if (result.requestId) res.setHeader("X-Provider-Request-Id", result.requestId);
       if (result.characterCost) res.setHeader("X-Provider-Character-Cost", result.characterCost);
       return res.send(result.audio);
     } catch (error: any) {
-      const message = error?.name === "AbortError" ? "voice_provider_timeout" : "voice_generation_failed";
+      const message = error?.name === "AbortError"
+        ? "voice_provider_timeout"
+        : error?.message === "voice_budget_state_unavailable"
+          ? "voice_budget_state_unavailable"
+          : "voice_generation_failed";
       console.error("Dragon voice error:", message);
       return res.status(502).json({ ok: false, error: message });
     } finally {
@@ -348,13 +560,14 @@ async function startServer() {
     console.log(`🚀 Universal Dragon Server running on http://localhost:${PORT}`);
     console.log(`📡 MQTT Broker: ${MQTT_BROKER}`);
     console.log(`🧠 NOVA AI Provider: ${process.env.GROQ_API_KEY ? "Groq" : process.env.OPENAI_API_KEY ? "OpenAI" : "Missing key"}`);
-    console.log(`🎙️ Dragon Voice: ${
-      process.env.ELEVENLABS_API_KEY
-      && process.env.ELEVENLABS_VOICE_ID
-      && process.env.DRAGON_VOICE_ACCESS_TOKEN
-        ? "ElevenLabs protected endpoint ready"
-        : "Not configured"
-    }`);
+    const provider = activeVoiceProvider();
+    console.log(
+      "🎙️ Dragon Voice: " + provider + (
+        isVoiceProviderConfigured(provider) && process.env.DRAGON_VOICE_ACCESS_TOKEN
+          ? " protected endpoint ready"
+          : " not configured"
+      ),
+    );
     console.log(`🔗 Socket.io: Active`);
   });
 }

--- a/server.ts
+++ b/server.ts
@@ -471,7 +471,7 @@ async function startServer() {
       }
 
       const budget = await reservePaidVoiceBudget(plan.spokenText.length);
-      if (!budget.allowed) {
+      if (budget.allowed === false) {
         return res.status(429).json({
           ok: false,
           error: budget.reason,
@@ -485,7 +485,7 @@ async function startServer() {
         ? await generateOpenAITtsSpeech(plan, profile)
         : await generateElevenV3Speech(plan);
 
-      if (!result.ok) {
+      if (result.ok === false) {
         return res.status(503).json({
           ok: false,
           error: result.reason,

--- a/server.ts
+++ b/server.ts
@@ -15,6 +15,7 @@ import {
   listDragonVoiceProfiles,
 } from "./src/voice/openaiTts";
 import {
+  normalizeVoiceUsage,
   parsePositiveInteger,
   reserveVoiceBudget,
   resolveDragonVoiceProvider,
@@ -95,7 +96,11 @@ async function reservePaidVoiceBudget(inputCharacters: number) {
     throw new Error("voice_budget_state_unavailable");
   }
 
-  const reservation = reserveVoiceBudget(current, voiceBudgetLimits(), inputCharacters, usageDate);
+  const reservation = reserveVoiceBudget(
+    normalizeVoiceUsage(current, usageDate),
+    voiceBudgetLimits(),
+    inputCharacters,
+  );
   if (!reservation.allowed) return reservation;
 
   try {

--- a/src/voice/openaiTts.ts
+++ b/src/voice/openaiTts.ts
@@ -1,0 +1,90 @@
+import type { DragonMood, VoiceSoulPlan } from './voiceSoul';
+
+export const DRAGON_VOICE_PROFILE_IDS = [
+  'NOVA',
+  'EVE',
+  'DRAGON',
+  'ANANYA',
+  'GUARDIAN',
+  'NARRATOR',
+] as const;
+
+export type DragonVoiceProfileId = (typeof DRAGON_VOICE_PROFILE_IDS)[number];
+
+export interface DragonVoiceProfile {
+  id: DragonVoiceProfileId;
+  label: string;
+  openaiVoice: 'alloy' | 'coral' | 'onyx' | 'sage' | 'marin' | 'cedar';
+  baseInstructions: string;
+}
+
+const profiles: Record<DragonVoiceProfileId, DragonVoiceProfile> = {
+  NOVA: {
+    id: 'NOVA',
+    label: 'NOVA',
+    openaiVoice: 'marin',
+    baseInstructions: 'Speak with a warm, clear, composed assistant voice.',
+  },
+  EVE: {
+    id: 'EVE',
+    label: 'EVE',
+    openaiVoice: 'cedar',
+    baseInstructions: 'Speak with a friendly, confident, helpful voice.',
+  },
+  DRAGON: {
+    id: 'DRAGON',
+    label: 'DRAGON',
+    openaiVoice: 'onyx',
+    baseInstructions: 'Speak with grounded, deliberate, protective authority.',
+  },
+  ANANYA: {
+    id: 'ANANYA',
+    label: 'ANANYA',
+    openaiVoice: 'coral',
+    baseInstructions: 'Speak with a bright, gentle, playful energy.',
+  },
+  GUARDIAN: {
+    id: 'GUARDIAN',
+    label: 'GUARDIAN',
+    openaiVoice: 'sage',
+    baseInstructions: 'Speak clearly, calmly, and firmly for safety guidance.',
+  },
+  NARRATOR: {
+    id: 'NARRATOR',
+    label: 'NARRATOR',
+    openaiVoice: 'alloy',
+    baseInstructions: 'Speak with a balanced, expressive storytelling voice.',
+  },
+};
+
+const moodInstructions: Record<DragonMood, string> = {
+  CALM: 'Use an even, reassuring pace.',
+  PLAYFUL: 'Use light, upbeat energy without exaggeration.',
+  CURIOUS: 'Use an engaged, thoughtful tone.',
+  SERIOUS: 'Use a concise, steady, serious tone.',
+  WHISPER: 'Use a soft, intimate, low-energy delivery.',
+};
+
+export function getDragonVoiceProfile(value?: string | null): DragonVoiceProfile {
+  const candidate = value?.trim().toUpperCase() as DragonVoiceProfileId | undefined;
+  const profile = candidate && candidate in profiles ? profiles[candidate] : profiles.NOVA;
+  return { ...profile };
+}
+
+export function listDragonVoiceProfiles(): Array<Pick<DragonVoiceProfile, 'id' | 'label' | 'openaiVoice'>> {
+  return DRAGON_VOICE_PROFILE_IDS.map((id) => {
+    const { label, openaiVoice } = profiles[id];
+    return { id, label, openaiVoice };
+  });
+}
+
+export function buildOpenAITtsInstructions(
+  plan: VoiceSoulPlan,
+  profile: DragonVoiceProfile,
+): string {
+  return [
+    profile.baseInstructions,
+    moodInstructions[plan.mood],
+    'Preserve the supplied wording. Do not add commentary or sound-effect labels.',
+  ].join(' ');
+}

--- a/src/voice/voiceBudget.ts
+++ b/src/voice/voiceBudget.ts
@@ -1,0 +1,83 @@
+export type DragonVoiceProvider = 'local' | 'openai' | 'elevenlabs';
+
+export interface VoiceUsageState {
+  date: string;
+  requestCount: number;
+  characterCount: number;
+}
+
+export interface VoiceBudgetLimits {
+  maxRequests: number;
+  maxCharacters: number;
+}
+
+export type VoiceBudgetReservation =
+  | { allowed: true; next: VoiceUsageState }
+  | {
+      allowed: false;
+      reason: 'voice_daily_request_limit' | 'voice_daily_character_limit';
+      next: VoiceUsageState;
+    };
+
+const PROVIDERS = new Set<DragonVoiceProvider>(['local', 'openai', 'elevenlabs']);
+
+function nonNegativeInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : 0;
+}
+
+export function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(1_000_000, Math.floor(parsed));
+}
+
+export function resolveDragonVoiceProvider(value: string | undefined): DragonVoiceProvider {
+  const candidate = value?.trim().toLowerCase() as DragonVoiceProvider | undefined;
+  return candidate && PROVIDERS.has(candidate) ? candidate : 'local';
+}
+
+export function utcVoiceUsageDate(now = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+export function normalizeVoiceUsage(
+  value: Partial<VoiceUsageState> | null | undefined,
+  date: string,
+): VoiceUsageState {
+  if (value?.date !== date) {
+    return { date, requestCount: 0, characterCount: 0 };
+  }
+
+  return {
+    date,
+    requestCount: nonNegativeInteger(value.requestCount),
+    characterCount: nonNegativeInteger(value.characterCount),
+  };
+}
+
+export function reserveVoiceBudget(
+  current: VoiceUsageState,
+  limits: VoiceBudgetLimits,
+  inputCharacters: number,
+): VoiceBudgetReservation {
+  const characters = nonNegativeInteger(inputCharacters);
+
+  if (current.requestCount >= limits.maxRequests) {
+    return { allowed: false, reason: 'voice_daily_request_limit', next: current };
+  }
+
+  if (current.characterCount + characters > limits.maxCharacters) {
+    return { allowed: false, reason: 'voice_daily_character_limit', next: current };
+  }
+
+  return {
+    allowed: true,
+    next: {
+      ...current,
+      requestCount: current.requestCount + 1,
+      characterCount: current.characterCount + characters,
+    },
+  };
+}

--- a/src/voice/voiceBudget.ts
+++ b/src/voice/voiceBudget.ts
@@ -42,18 +42,20 @@ export function utcVoiceUsageDate(now = new Date()): string {
   return now.toISOString().slice(0, 10);
 }
 
-export function normalizeVoiceUsage(
-  value: Partial<VoiceUsageState> | null | undefined,
-  date: string,
-): VoiceUsageState {
-  if (value?.date !== date) {
+export function normalizeVoiceUsage(value: unknown, date: string): VoiceUsageState {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { date, requestCount: 0, characterCount: 0 };
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (candidate.date !== date) {
     return { date, requestCount: 0, characterCount: 0 };
   }
 
   return {
     date,
-    requestCount: nonNegativeInteger(value.requestCount),
-    characterCount: nonNegativeInteger(value.characterCount),
+    requestCount: nonNegativeInteger(candidate.requestCount),
+    characterCount: nonNegativeInteger(candidate.characterCount),
   };
 }
 

--- a/tools/proof_voice_gateway.ts
+++ b/tools/proof_voice_gateway.ts
@@ -64,7 +64,7 @@ const blockedByCharacters = reserveVoiceBudget(
   101,
 );
 assert.equal(blockedByCharacters.allowed, false);
-if (!blockedByCharacters.allowed) {
+if (blockedByCharacters.allowed === false) {
   assert.equal(blockedByCharacters.reason, 'voice_daily_character_limit');
 }
 

--- a/tools/proof_voice_gateway.ts
+++ b/tools/proof_voice_gateway.ts
@@ -41,10 +41,11 @@ const current = normalizeVoiceUsage(
 );
 const accepted = reserveVoiceBudget(current, { maxRequests: 6, maxCharacters: 2_400 }, 400);
 assert.equal(accepted.allowed, true);
-if (accepted.allowed) {
-  assert.equal(accepted.next.requestCount, 6);
-  assert.equal(accepted.next.characterCount, 2_400);
+if (!accepted.allowed) {
+  throw new Error('Expected accepted voice budget reservation');
 }
+assert.equal(accepted.next.requestCount, 6);
+assert.equal(accepted.next.characterCount, 2_400);
 
 const blockedByRequests = reserveVoiceBudget(
   accepted.next,

--- a/tools/proof_voice_gateway.ts
+++ b/tools/proof_voice_gateway.ts
@@ -1,0 +1,72 @@
+import { strict as assert } from 'node:assert';
+import {
+  buildOpenAITtsInstructions,
+  getDragonVoiceProfile,
+  listDragonVoiceProfiles,
+} from '../src/voice/openaiTts';
+import {
+  normalizeVoiceUsage,
+  parsePositiveInteger,
+  reserveVoiceBudget,
+  resolveDragonVoiceProvider,
+} from '../src/voice/voiceBudget';
+import { planVoiceSoul } from '../src/voice/voiceSoul';
+
+const profiles = listDragonVoiceProfiles();
+assert.equal(profiles.length, 6);
+assert.deepEqual(
+  profiles.map((profile) => profile.id),
+  ['NOVA', 'EVE', 'DRAGON', 'ANANYA', 'GUARDIAN', 'NARRATOR'],
+);
+assert.equal(getDragonVoiceProfile('eve').openaiVoice, 'cedar');
+assert.equal(getDragonVoiceProfile('unknown').id, 'NOVA');
+
+const plan = planVoiceSoul({
+  context: 'WAKE',
+  text: 'Dragon Resonance active.',
+  mood: 'PLAYFUL',
+});
+const instructions = buildOpenAITtsInstructions(plan, getDragonVoiceProfile('NOVA'));
+assert.ok(instructions.includes('warm, clear, composed'));
+assert.ok(instructions.includes('upbeat energy'));
+
+assert.equal(resolveDragonVoiceProvider('openai'), 'openai');
+assert.equal(resolveDragonVoiceProvider('invalid'), 'local');
+assert.equal(parsePositiveInteger('0', 6), 6);
+assert.equal(parsePositiveInteger('12', 6), 12);
+
+const current = normalizeVoiceUsage(
+  { date: '2026-08-14', requestCount: 5, characterCount: 2_000 },
+  '2026-08-14',
+);
+const accepted = reserveVoiceBudget(current, { maxRequests: 6, maxCharacters: 2_400 }, 400);
+assert.equal(accepted.allowed, true);
+if (accepted.allowed) {
+  assert.equal(accepted.next.requestCount, 6);
+  assert.equal(accepted.next.characterCount, 2_400);
+}
+
+const blockedByRequests = reserveVoiceBudget(
+  accepted.next,
+  { maxRequests: 6, maxCharacters: 2_400 },
+  1,
+);
+assert.deepEqual(blockedByRequests, {
+  allowed: false,
+  reason: 'voice_daily_request_limit',
+  next: accepted.next,
+});
+
+const blockedByCharacters = reserveVoiceBudget(
+  { date: '2026-08-14', requestCount: 1, characterCount: 2_300 },
+  { maxRequests: 6, maxCharacters: 2_400 },
+  101,
+);
+assert.equal(blockedByCharacters.allowed, false);
+if (!blockedByCharacters.allowed) {
+  assert.equal(blockedByCharacters.reason, 'voice_daily_character_limit');
+}
+
+console.log('OPENAI_VOICE_PROFILES=PASS');
+console.log('VOICE_BUDGET_GUARD=PASS');
+console.log('DRAGON_VOICE_GATEWAY=PASS');


### PR DESCRIPTION
## Summary

Builds on #24 without modifying QBIT files.

- Adds six named built-in voice profiles: NOVA, EVE, DRAGON, ANANYA, GUARDIAN, and NARRATOR.
- Adds optional OpenAI TTS through the existing server-side `OPENAI_API_KEY`; no key is copied, returned, logged, or committed.
- Makes `local` the default provider, returning client-TTS instructions with no paid provider request.
- Requires both a protected bearer token and strict `"premium": true` before any OpenAI or ElevenLabs request.
- Adds conservative per-day request and character caps with local persisted usage state; budget is reserved before provider contact and fails closed if state cannot be read or written.
- Keeps the existing ElevenLabs option intact.
- Adds deterministic gateway proof and CI checks. No live TTS request was made while implementing or testing this PR.

## Runtime activation (not performed by this PR)

Set `DRAGON_VOICE_PROVIDER=openai` only in the Pi5 service environment after reviewing the caps and access token. Otherwise it remains local/no-cost by default.

## Safety notes

- No QBIT source files changed.
- No secrets, tokens, voice IDs, or populated environment files are included.
- Audio from paid providers carries `X-Dragon-AI-Generated: true`; the client must disclose AI-generated speech before playback.

Depends on #24.