### PR TITLE
feat: Dragon Local Voice V1 + Human Voice Soul V2 for Pi5

### DIFF
--- a/.github/workflows/dragon-local-voice-v1.yml
+++ b/.github/workflows/dragon-local-voice-v1.yml
@@ -55,3 +55,27 @@ jobs:
           fi
           echo 'MODEL_WEIGHT_COMMIT=NO'
           echo 'DRAGON_LOCAL_VOICE_CI=PASS'
+
+      - name: Build portable handoff ZIP
+        run: |
+          set -euo pipefail
+          mkdir -p build/dragon-local-voice-v1/room-magic/termux
+          cp -a local-voice build/dragon-local-voice-v1/
+          cp room-magic/termux/voice-local-pi5.sh build/dragon-local-voice-v1/room-magic/termux/
+          (
+            cd build
+            zip -qr dragon-local-voice-v1-handoff.zip dragon-local-voice-v1
+          )
+          test -s build/dragon-local-voice-v1-handoff.zip
+          sha256sum build/dragon-local-voice-v1-handoff.zip | tee build/dragon-local-voice-v1-handoff.sha256
+          echo 'PORTABLE_VOICE_HANDOFF=PASS'
+
+      - name: Upload portable handoff
+        uses: actions/upload-artifact@v4
+        with:
+          name: dragon-local-voice-v1-handoff
+          path: |
+            build/dragon-local-voice-v1-handoff.zip
+            build/dragon-local-voice-v1-handoff.sha256
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/dragon-local-voice-v1.yml
+++ b/.github/workflows/dragon-local-voice-v1.yml
@@ -1,0 +1,57 @@
+name: Dragon Local Voice V1
+
+on:
+  push:
+    branches:
+      - feat/dragon-local-voice-v1
+  pull_request:
+    paths:
+      - 'local-voice/**'
+      - 'room-magic/termux/voice-local-pi5.sh'
+      - '.github/workflows/dragon-local-voice-v1.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  static-proof:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Python and profile contract
+        run: python local-voice/verify_static.py
+
+      - name: Shell syntax
+        run: |
+          bash -n local-voice/install-pi5.sh
+          bash -n room-magic/termux/voice-local-pi5.sh
+          echo 'LOCAL_VOICE_SHELL_SYNTAX=PASS'
+
+      - name: Secret and paid-provider guard
+        run: |
+          set -euo pipefail
+          ! grep -R -nE 'sk-[A-Za-z0-9_-]{16,}|xi-api-key:[[:space:]]*[^$]' local-voice room-magic/termux/voice-local-pi5.sh
+          grep -q 'PAID_API_USED=NO' local-voice/install-pi5.sh
+          grep -q 'ELEVENLABS_REQUIRED=NO' local-voice/install-pi5.sh
+          grep -q 'V3D_TTS_INFERENCE_CLAIMED=NO' local-voice/install-pi5.sh
+          echo 'LOCAL_VOICE_SECRET_GUARD=PASS'
+
+      - name: No committed voice weights
+        run: |
+          set -euo pipefail
+          if find local-voice -type f \( -name '*.onnx' -o -name '*.pt' -o -name '*.pth' -o -name '*.ckpt' \) | grep -q .; then
+            echo 'MODEL_WEIGHT_COMMIT=FAIL'
+            exit 1
+          fi
+          echo 'MODEL_WEIGHT_COMMIT=NO'
+          echo 'DRAGON_LOCAL_VOICE_CI=PASS'

--- a/.github/workflows/dragon-local-voice-v1.yml
+++ b/.github/workflows/dragon-local-voice-v1.yml
@@ -65,7 +65,7 @@ jobs:
             exit 1
           fi
 
-          if git grep -nE 'sk-[A-Za-z0-9_-]{16,}|xi-api-key:[[:space:]]*[^$]' -- "${SCAN_PATHS[@]}"; then
+          if git grep -nE 'sk-[A-Za-z0-9_-]{16,}|xi-api-key:[[:space:]]+[A-Za-z0-9_-]{16,}' -- "${SCAN_PATHS[@]}"; then
             echo 'PAID_PROVIDER_SECRET=FAIL'
             exit 1
           fi
@@ -98,10 +98,10 @@ jobs:
           cp room-magic/termux/voice-local-pi5-v2.sh build/dragon-local-voice-v2/room-magic/termux/
           cp src/voice/localPi.ts build/dragon-local-voice-v2/src/voice/
           find build -type d -name '__pycache__' -prune -exec rm -rf {} +
-          find build -type f \( -name '.env' -o -name '*.wav' -o -name '*.onnx' -o -name '*.pt' -o -name '*.pth' \) -print -quit | grep -q . && {
+          if find build -type f \( -name '.env' -o -name '*.wav' -o -name '*.onnx' -o -name '*.pt' -o -name '*.pth' \) -print -quit | grep -q .; then
             echo 'HANDOFF_SECRET_OR_WEIGHT=FAIL'
             exit 1
-          } || true
+          fi
           (
             cd build
             zip -qr dragon-local-voice-v2-handoff.zip dragon-local-voice-v2

--- a/.github/workflows/dragon-local-voice-v1.yml
+++ b/.github/workflows/dragon-local-voice-v1.yml
@@ -1,4 +1,4 @@
-name: Dragon Local Voice V1
+name: Dragon Local Voice V1 + Human Voice Soul V2
 
 on:
   push:
@@ -8,15 +8,20 @@ on:
     paths:
       - 'local-voice/**'
       - 'room-magic/termux/voice-local-pi5.sh'
+      - 'room-magic/termux/voice-local-pi5-v2.sh'
+      - 'src/voice/localPi.ts'
       - '.github/workflows/dragon-local-voice-v1.yml'
 
 permissions:
   contents: read
 
+env:
+  PYTHONDONTWRITEBYTECODE: '1'
+
 jobs:
   static-proof:
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,54 +33,91 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Python and profile contract
+      - name: V1 static contract
         run: python local-voice/verify_static.py
+
+      - name: V2 Human Voice Soul contract
+        run: python local-voice/v2/verify_v2_static.py
 
       - name: Shell syntax
         run: |
+          set -euo pipefail
           bash -n local-voice/install-pi5.sh
+          bash -n local-voice/v2/install-v2-pi5.sh
+          bash -n local-voice/v2/install-nano-pi5.sh
+          bash -n local-voice/v2/proof-seven-voices.sh
           bash -n room-magic/termux/voice-local-pi5.sh
+          bash -n room-magic/termux/voice-local-pi5-v2.sh
           echo 'LOCAL_VOICE_SHELL_SYNTAX=PASS'
 
       - name: Secret and paid-provider guard
         run: |
           set -euo pipefail
-          ! grep -R -nE 'sk-[A-Za-z0-9_-]{16,}|xi-api-key:[[:space:]]*[^$]' local-voice room-magic/termux/voice-local-pi5.sh
+          SCAN_PATHS=(local-voice room-magic/termux src/voice/localPi.ts)
+
+          if git ls-files 'local-voice/**' | grep -Eq '(^|/)\.env$'; then
+            echo 'TRACKED_LOCAL_ENV=FAIL'
+            exit 1
+          fi
+
+          if git grep -nE 'DRAGON_VOICE_TOKEN=[A-Za-z0-9_-]{16,}' -- "${SCAN_PATHS[@]}"; then
+            echo 'HARDCODED_DRAGON_TOKEN=FAIL'
+            exit 1
+          fi
+
+          if git grep -nE 'sk-[A-Za-z0-9_-]{16,}|xi-api-key:[[:space:]]*[^$]' -- "${SCAN_PATHS[@]}"; then
+            echo 'PAID_PROVIDER_SECRET=FAIL'
+            exit 1
+          fi
+
           grep -q 'PAID_API_USED=NO' local-voice/install-pi5.sh
           grep -q 'ELEVENLABS_REQUIRED=NO' local-voice/install-pi5.sh
           grep -q 'V3D_TTS_INFERENCE_CLAIMED=NO' local-voice/install-pi5.sh
+          grep -q 'PAID_API_USED=NO' local-voice/v2/install-v2-pi5.sh
+          grep -q 'V3D_TTS_INFERENCE_CLAIMED=NO' local-voice/v2/install-v2-pi5.sh
           echo 'LOCAL_VOICE_SECRET_GUARD=PASS'
 
-      - name: No committed voice weights
+      - name: No committed voice weights or references
         run: |
           set -euo pipefail
-          if find local-voice -type f \( -name '*.onnx' -o -name '*.pt' -o -name '*.pth' -o -name '*.ckpt' \) | grep -q .; then
-            echo 'MODEL_WEIGHT_COMMIT=FAIL'
+          if find local-voice -type f \( -name '*.onnx' -o -name '*.pt' -o -name '*.pth' -o -name '*.ckpt' -o -name '*.wav' \) | grep -q .; then
+            echo 'VOICE_WEIGHT_OR_REFERENCE_COMMIT=FAIL'
             exit 1
           fi
-          echo 'MODEL_WEIGHT_COMMIT=NO'
+          echo 'VOICE_WEIGHT_OR_REFERENCE_COMMIT=NO'
           echo 'DRAGON_LOCAL_VOICE_CI=PASS'
 
-      - name: Build portable handoff ZIP
+      - name: Build portable V2 handoff ZIP
         run: |
           set -euo pipefail
-          mkdir -p build/dragon-local-voice-v1/room-magic/termux
-          cp -a local-voice build/dragon-local-voice-v1/
-          cp room-magic/termux/voice-local-pi5.sh build/dragon-local-voice-v1/room-magic/termux/
+          rm -rf build
+          mkdir -p build/dragon-local-voice-v2/room-magic/termux
+          mkdir -p build/dragon-local-voice-v2/src/voice
+          cp -a local-voice build/dragon-local-voice-v2/
+          cp room-magic/termux/voice-local-pi5.sh build/dragon-local-voice-v2/room-magic/termux/
+          cp room-magic/termux/voice-local-pi5-v2.sh build/dragon-local-voice-v2/room-magic/termux/
+          cp src/voice/localPi.ts build/dragon-local-voice-v2/src/voice/
+          find build -type d -name '__pycache__' -prune -exec rm -rf {} +
+          find build -type f \( -name '.env' -o -name '*.wav' -o -name '*.onnx' -o -name '*.pt' -o -name '*.pth' \) -print -quit | grep -q . && {
+            echo 'HANDOFF_SECRET_OR_WEIGHT=FAIL'
+            exit 1
+          } || true
           (
             cd build
-            zip -qr dragon-local-voice-v1-handoff.zip dragon-local-voice-v1
+            zip -qr dragon-local-voice-v2-handoff.zip dragon-local-voice-v2
+            sha256sum dragon-local-voice-v2-handoff.zip > dragon-local-voice-v2-handoff.sha256
           )
-          test -s build/dragon-local-voice-v1-handoff.zip
-          sha256sum build/dragon-local-voice-v1-handoff.zip | tee build/dragon-local-voice-v1-handoff.sha256
-          echo 'PORTABLE_VOICE_HANDOFF=PASS'
+          test -s build/dragon-local-voice-v2-handoff.zip
+          grep -Eq '^[0-9a-f]{64}  dragon-local-voice-v2-handoff\.zip$' build/dragon-local-voice-v2-handoff.sha256
+          echo 'PORTABLE_V2_CHECKSUM_PATH=PASS'
+          echo 'PORTABLE_VOICE_V2_HANDOFF=PASS'
 
-      - name: Upload portable handoff
+      - name: Upload portable V2 handoff
         uses: actions/upload-artifact@v4
         with:
-          name: dragon-local-voice-v1-handoff
+          name: dragon-local-voice-v2-handoff
           path: |
-            build/dragon-local-voice-v1-handoff.zip
-            build/dragon-local-voice-v1-handoff.sha256
+            build/dragon-local-voice-v2-handoff.zip
+            build/dragon-local-voice-v2-handoff.sha256
           if-no-files-found: error
           retention-days: 14

--- a/docs/DRAGON_HUMAN_VOICE_SOUL_V2.md
+++ b/docs/DRAGON_HUMAN_VOICE_SOUL_V2.md
@@ -1,0 +1,98 @@
+# Dragon Human Voice Soul V2
+
+Human Voice Soul V2 is the local expressive layer above the already-proven Pi5 Piper V1 service.
+
+## Goal
+
+One local voice service for NOVA, EVE, Novakutty, Room Magic, WhatsApp voice replies, phone clients, and future robot/device adapters.
+
+The target is human-like variation, not a single generic TTS voice. The system separates **identity**, **mood**, **context**, **reaction**, and **engine** so the assistant can change delivery without changing its safety or truth boundary.
+
+## Seven identities
+
+- `nova_warm` — warm everyday assistant
+- `dragon_playful` — smiling/playful energy
+- `dragon_serious` — firm controlled delivery
+- `dragon_deep` — mature cinematic authority
+- `whatsapp_natural` — casual short voice-note delivery
+- `story_soul` — measured storyteller
+- `night_whisper` — soft late-night presence
+
+These are original Dragon identity slots. They are not claims of an exact real actor or public figure voice.
+
+## Mood and reaction controls
+
+Planner moods:
+
+`neutral`, `smile`, `laugh`, `serious`, `whisper`, `sad`, `confident`, `curious`, `alert`
+
+Contexts:
+
+`chat`, `whatsapp`, `wake`, `story`, `robot`, `alert`, `night`
+
+Reaction routing includes bounded plans for laugh/chuckle/cough and non-native fallbacks such as sigh/breath. Only upstream-confirmed Chatterbox reaction tags are emitted directly by the Nano lane.
+
+## Engine order
+
+1. **Kokoro** — primary lightweight multi-identity natural speech lane.
+2. **Chatterbox Nano** — optional expressive/paralinguistic lane. A local permissioned reference WAV is required by default when identity preservation matters.
+3. **Piper V1** — already-proven fail-safe local fallback.
+
+The router can be forced to a single engine for testing, or set to `auto` for fallback behavior.
+
+## Security boundary
+
+- local bearer token is required; missing token fails closed
+- token remains in the existing Pi5 V1 `.env` and is not committed
+- reference WAV files remain local and are not committed
+- model paths/reference paths reject traversal
+- speech text is bounded to 1200 characters
+- private-reasoning markup and arbitrary bracketed audio-tag injection are removed before planning
+- services bind to loopback by default
+
+## Truth boundary
+
+- paid API required: **no**
+- ElevenLabs required: **no**
+- Pi5 V3D TTS inference claimed: **no**
+- exact real-person voice cloning claimed: **no**
+- V1 Piper runtime proof: **complete on real Pi5**
+- V2 Kokoro runtime proof on Pi5: **required before V2 merge**
+- Chatterbox Nano runtime/audio benchmark on Pi5: **required before claiming practical real-time performance**
+
+## Pi5 files
+
+- `local-voice/v2/voice_soul_v2.py` — provider-independent planner
+- `local-voice/v2/dragon_voice_v2_server.py` — V2 API/router
+- `local-voice/v2/profiles-v2.json` — seven identities
+- `local-voice/v2/install-v2-pi5.sh` — Kokoro V2 install/proof
+- `local-voice/v2/install-nano-pi5.sh` — optional Nano install
+- `local-voice/v2/proof-seven-voices.sh` — generate seven local identity proofs
+- `room-magic/termux/voice-local-pi5-v2.sh` — Huawei/Termux client
+
+## API
+
+Local default: `http://127.0.0.1:8124`
+
+- `GET /health`
+- `GET /v2/profiles` — authenticated
+- `POST /v2/plan` — authenticated
+- `POST /v2/speak` — authenticated
+
+Example request body:
+
+```json
+{
+  "text": "Bro, I am here.",
+  "profile": "whatsapp_natural",
+  "mood": "smile",
+  "context": "whatsapp",
+  "reaction": "none",
+  "engine": "auto",
+  "intensity": 0.68
+}
+```
+
+## Voice references
+
+Any reference WAV used by the Nano lane must be a voice the project owner has permission to use. Reference files stay under the local V2 `references/` directory and are deliberately excluded from Git and CI artifacts.

--- a/docs/DRAGON_LOCAL_VOICE_V1.md
+++ b/docs/DRAGON_LOCAL_VOICE_V1.md
@@ -1,0 +1,118 @@
+# Universal Dragon Local Voice V1
+
+## Goal
+
+Run speech generation on the Raspberry Pi 5 without ElevenLabs or another paid speech API, while preserving the existing provider-independent Dragon Voice Soul planner.
+
+## V1 architecture
+
+```text
+NOVA / EVE / WhatsApp reply
+        |
+        v
+Dragon Voice Soul planner
+        |
+        v
+Dragon Local Voice API :8123
+        |
+        v
+Piper / ONNX Runtime
+        |
+        v
+WAV audio
+```
+
+The local service binds to `127.0.0.1` by default and is intended to be exposed only through an authenticated local adapter or a separately configured Cloudflare tunnel.
+
+## Seven voice-profile slots
+
+V1 defines seven stable identities:
+
+- `nova_warm`
+- `dragon_playful`
+- `dragon_serious`
+- `dragon_deep`
+- `whatsapp_natural`
+- `story_soul`
+- `night_whisper`
+
+A profile is not falsely claimed to be a distinct trained speaker until its dedicated ONNX model exists. Missing dedicated models fall back to the bootstrap model and the HTTP response exposes `X-Dragon-Model-Fallback: yes`.
+
+## Truth boundary
+
+- No OpenAI API key required for speech generation.
+- No ElevenLabs key required.
+- No paid speech provider required.
+- Pi5 V3D GPU inference is **not** claimed in V1.
+- The already-proven V3D/Vulkan work is a separate accelerator path. Piper uses ONNX Runtime; CUDA flags from upstream do not turn Raspberry Pi V3D into CUDA.
+- V1 establishes a truthful local CPU baseline first. A later measured accelerator stage may add custom V3D kernels only where evidence shows a real benefit.
+
+## Pi5 install
+
+From a checkout of this branch:
+
+```bash
+bash local-voice/install-pi5.sh
+```
+
+Expected final markers:
+
+```text
+SYSTEM_DEPENDENCIES=PASS
+PYTHON_ENV=PASS
+BOOTSTRAP_MODEL=PASS
+LOCAL_SECRET_FILE=PASS
+SERVICE_INSTALL=PASS
+LOCAL_VOICE_HEALTH=PASS
+LOCAL_WAV_GENERATION=PASS
+PAID_API_USED=NO
+ELEVENLABS_REQUIRED=NO
+V3D_TTS_INFERENCE_CLAIMED=NO
+DRAGON_LOCAL_VOICE_V1=PASS
+```
+
+The generated proof audio is stored at:
+
+```text
+~/dragon-local-voice-v1/proof.wav
+```
+
+## API
+
+Health:
+
+```bash
+curl http://127.0.0.1:8123/health
+```
+
+Synthesis:
+
+```bash
+source ~/dragon-local-voice-v1/.env
+curl -H "Authorization: Bearer $DRAGON_VOICE_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Hi Aslam, NOVA is online.","profile":"whatsapp_natural","intensity":0.65}' \
+  http://127.0.0.1:8123/v1/speak \
+  -o reply.wav
+```
+
+## Huawei / Termux handoff
+
+`room-magic/termux/voice-local-pi5.sh` is a small client. Point it at the protected Pi endpoint with local-only environment variables and it downloads a WAV voice reply.
+
+## Voice model policy
+
+Model weights are never committed automatically. Put trained or licensed ONNX files in the Pi model directory. Each third-party voice model has its own license, so its model card must be reviewed before commercial distribution.
+
+The bootstrap engine is Piper from the Open Home Foundation. Piper supports arm64 and custom voice training, but Piper itself is GPL-3.0-or-later. Keep the engine isolated behind this service boundary and perform a license review before shipping a closed-source commercial appliance.
+
+## Quality roadmap
+
+V1 is the reliable offline speech floor, not a claim that one bootstrap voice already beats ElevenLabs. The path to that target is:
+
+1. establish Pi5 latency and audio-quality baseline;
+2. collect or license clean training audio for owned Dragon voices;
+3. train/fine-tune dedicated models for the seven profile slots;
+4. measure naturalness, speaker consistency, Tamil/Tanglish pronunciation and latency;
+5. add expressive breath/laugh/pacing controls in the Voice Soul planner;
+6. benchmark any V3D acceleration separately and fail closed on CPU fallback when a GPU claim is made.

--- a/local-voice/.gitignore
+++ b/local-voice/.gitignore
@@ -1,0 +1,9 @@
+models/*.onnx
+models/*.onnx.json
+models/*.pt
+models/*.pth
+models/*.ckpt
+.env
+.venv/
+__pycache__/
+*.wav

--- a/local-voice/.gitignore
+++ b/local-voice/.gitignore
@@ -4,6 +4,13 @@ models/*.pt
 models/*.pth
 models/*.ckpt
 .env
+runtime.env
 .venv/
 __pycache__/
+cache/
 *.wav
+*.headers
+health.json
+plan-proof.json
+nano-health.json
+seven-voice-proof/

--- a/local-voice/dragon_voice_server.py
+++ b/local-voice/dragon_voice_server.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import hmac
+import io
+import json
+import os
+import threading
+import time
+import wave
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+from piper import PiperVoice, SynthesisConfig
+
+APP_DIR = Path(__file__).resolve().parent
+MODEL_DIR = Path(os.environ.get("DRAGON_VOICE_MODEL_DIR", APP_DIR / "models")).expanduser().resolve()
+PROFILES_PATH = Path(os.environ.get("DRAGON_VOICE_PROFILES", APP_DIR / "profiles.json")).expanduser().resolve()
+ACCESS_TOKEN = os.environ.get("DRAGON_VOICE_TOKEN", "")
+MAX_TEXT_CHARS = int(os.environ.get("DRAGON_VOICE_MAX_TEXT", "1200"))
+
+app = FastAPI(title="Universal Dragon Local Voice", version="1.0.0")
+_cache_lock = threading.Lock()
+_synthesis_lock = threading.Lock()
+_voice_cache: dict[str, PiperVoice] = {}
+
+
+def _load_profiles() -> dict[str, Any]:
+    data = json.loads(PROFILES_PATH.read_text(encoding="utf-8"))
+    if data.get("schema") != "dragon.local-voice.profiles.v1":
+        raise RuntimeError("unsupported voice profile schema")
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict) or not profiles:
+        raise RuntimeError("voice profiles missing")
+    if data.get("default_profile") not in profiles:
+        raise RuntimeError("default profile missing")
+    return data
+
+
+PROFILES = _load_profiles()
+
+
+def _authorized(authorization: str | None) -> bool:
+    if not ACCESS_TOKEN:
+        return True
+    if not authorization or not authorization.lower().startswith("bearer "):
+        return False
+    candidate = authorization.split(" ", 1)[1].strip()
+    return bool(candidate) and hmac.compare_digest(candidate, ACCESS_TOKEN)
+
+
+def _require_auth(authorization: str | None) -> None:
+    if not _authorized(authorization):
+        raise HTTPException(status_code=401, detail="unauthorized", headers={"WWW-Authenticate": "Bearer"})
+
+
+def _safe_model_path(filename: str) -> Path:
+    if not filename or Path(filename).name != filename:
+        raise RuntimeError("invalid model filename")
+    path = (MODEL_DIR / filename).resolve()
+    if path.parent != MODEL_DIR:
+        raise RuntimeError("model path escaped model directory")
+    return path
+
+
+def _resolve_profile(name: str) -> tuple[str, dict[str, Any]]:
+    profiles: dict[str, Any] = PROFILES["profiles"]
+    selected = name if name in profiles else PROFILES["default_profile"]
+    return selected, profiles[selected]
+
+
+def _get_voice(profile: dict[str, Any]) -> tuple[PiperVoice, Path, bool]:
+    requested = _safe_model_path(str(profile["model"]))
+    fallback = False
+    model_path = requested
+
+    if not model_path.is_file():
+        model_path = _safe_model_path(str(PROFILES["default_model"]))
+        fallback = True
+
+    if not model_path.is_file():
+        raise HTTPException(
+            status_code=503,
+            detail=f"voice model unavailable: {requested.name}; bootstrap model missing: {model_path.name}",
+        )
+
+    key = str(model_path)
+    with _cache_lock:
+        voice = _voice_cache.get(key)
+        if voice is None:
+            voice = PiperVoice.load(key)
+            _voice_cache[key] = voice
+    return voice, model_path, fallback
+
+
+def _synthesis_config(profile: dict[str, Any], intensity: float) -> SynthesisConfig:
+    intensity = max(0.0, min(1.0, intensity))
+    base_noise = float(profile.get("noise_scale", 0.667))
+    base_width = float(profile.get("noise_w_scale", 0.8))
+    # Keep profile character bounded. Intensity only nudges variation, never model identity.
+    noise_scale = max(0.1, min(1.5, base_noise * (0.9 + 0.2 * intensity)))
+    noise_w_scale = max(0.1, min(1.5, base_width * (0.9 + 0.2 * intensity)))
+    return SynthesisConfig(
+        volume=float(profile.get("volume", 1.0)),
+        length_scale=float(profile.get("length_scale", 1.0)),
+        noise_scale=noise_scale,
+        noise_w_scale=noise_w_scale,
+        normalize_audio=True,
+    )
+
+
+class SpeakRequest(BaseModel):
+    text: str = Field(min_length=1, max_length=MAX_TEXT_CHARS)
+    profile: str = "nova_warm"
+    intensity: float = Field(default=0.65, ge=0.0, le=1.0)
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    profiles: dict[str, Any] = PROFILES["profiles"]
+    installed = []
+    for name, profile in profiles.items():
+        try:
+            present = _safe_model_path(str(profile["model"])).is_file()
+        except RuntimeError:
+            present = False
+        installed.append({"profile": name, "dedicated_model": present})
+
+    default_path = _safe_model_path(str(PROFILES["default_model"]))
+    return {
+        "ok": True,
+        "schema": "dragon.local-voice.health.v1",
+        "engine": "piper",
+        "backend": "onnxruntime",
+        "device_claim": "cpu-baseline",
+        "v3d_voice_inference_claimed": False,
+        "profile_count": len(profiles),
+        "default_model_ready": default_path.is_file(),
+        "profiles": installed,
+        "paid_api_required": False,
+    }
+
+
+@app.get("/v1/profiles")
+def list_profiles(authorization: str | None = Header(default=None)) -> dict[str, Any]:
+    _require_auth(authorization)
+    public_profiles = []
+    for name, profile in PROFILES["profiles"].items():
+        public_profiles.append(
+            {
+                "id": name,
+                "display_name": profile["display_name"],
+                "character": profile["character"],
+                "dedicated_model_ready": _safe_model_path(str(profile["model"])).is_file(),
+            }
+        )
+    return {
+        "schema": "dragon.local-voice.profile-list.v1",
+        "default_profile": PROFILES["default_profile"],
+        "profiles": public_profiles,
+    }
+
+
+@app.post("/v1/speak")
+def speak(request: SpeakRequest, authorization: str | None = Header(default=None)) -> Response:
+    _require_auth(authorization)
+    profile_name, profile = _resolve_profile(request.profile)
+    voice, model_path, fallback = _get_voice(profile)
+    syn_config = _synthesis_config(profile, request.intensity)
+
+    started = time.perf_counter()
+    buffer = io.BytesIO()
+    with _synthesis_lock:
+        with wave.open(buffer, "wb") as wav_file:
+            voice.synthesize_wav(request.text.strip(), wav_file, syn_config=syn_config)
+    elapsed_ms = int((time.perf_counter() - started) * 1000)
+
+    return Response(
+        content=buffer.getvalue(),
+        media_type="audio/wav",
+        headers={
+            "Cache-Control": "no-store",
+            "X-Dragon-Voice-Profile": profile_name,
+            "X-Dragon-Voice-Model": model_path.name,
+            "X-Dragon-Model-Fallback": "yes" if fallback else "no",
+            "X-Dragon-Inference-Ms": str(elapsed_ms),
+            "X-Dragon-Paid-API": "no",
+            "X-Dragon-Device-Claim": "cpu-baseline",
+        },
+    )

--- a/local-voice/dragon_voice_server.py
+++ b/local-voice/dragon_voice_server.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from fastapi import FastAPI, Header, HTTPException
 from fastapi.responses import Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from piper import PiperVoice, SynthesisConfig
 
 APP_DIR = Path(__file__).resolve().parent
@@ -21,13 +21,14 @@ PROFILES_PATH = Path(os.environ.get("DRAGON_VOICE_PROFILES", APP_DIR / "profiles
 ACCESS_TOKEN = os.environ.get("DRAGON_VOICE_TOKEN", "")
 MAX_TEXT_CHARS = int(os.environ.get("DRAGON_VOICE_MAX_TEXT", "1200"))
 
-app = FastAPI(title="Universal Dragon Local Voice", version="1.0.0")
+app = FastAPI(title="Universal Dragon Local Voice", version="1.0.1")
 _cache_lock = threading.Lock()
 _synthesis_lock = threading.Lock()
 _voice_cache: dict[str, PiperVoice] = {}
 
 
 def _load_profiles() -> dict[str, Any]:
+    """Load and validate the local voice profile contract."""
     data = json.loads(PROFILES_PATH.read_text(encoding="utf-8"))
     if data.get("schema") != "dragon.local-voice.profiles.v1":
         raise RuntimeError("unsupported voice profile schema")
@@ -43,8 +44,9 @@ PROFILES = _load_profiles()
 
 
 def _authorized(authorization: str | None) -> bool:
+    """Validate the configured bearer token with constant-time comparison."""
     if not ACCESS_TOKEN:
-        return True
+        return False
     if not authorization or not authorization.lower().startswith("bearer "):
         return False
     candidate = authorization.split(" ", 1)[1].strip()
@@ -52,11 +54,13 @@ def _authorized(authorization: str | None) -> bool:
 
 
 def _require_auth(authorization: str | None) -> None:
+    """Reject unauthenticated synthesis/profile requests."""
     if not _authorized(authorization):
         raise HTTPException(status_code=401, detail="unauthorized", headers={"WWW-Authenticate": "Bearer"})
 
 
 def _safe_model_path(filename: str) -> Path:
+    """Resolve a model filename without allowing path traversal."""
     if not filename or Path(filename).name != filename:
         raise RuntimeError("invalid model filename")
     path = (MODEL_DIR / filename).resolve()
@@ -66,12 +70,14 @@ def _safe_model_path(filename: str) -> Path:
 
 
 def _resolve_profile(name: str) -> tuple[str, dict[str, Any]]:
+    """Return a requested profile or the configured default profile."""
     profiles: dict[str, Any] = PROFILES["profiles"]
     selected = name if name in profiles else PROFILES["default_profile"]
     return selected, profiles[selected]
 
 
 def _get_voice(profile: dict[str, Any]) -> tuple[PiperVoice, Path, bool]:
+    """Load and cache a dedicated Piper model or the bootstrap fallback."""
     requested = _safe_model_path(str(profile["model"]))
     fallback = False
     model_path = requested
@@ -96,10 +102,10 @@ def _get_voice(profile: dict[str, Any]) -> tuple[PiperVoice, Path, bool]:
 
 
 def _synthesis_config(profile: dict[str, Any], intensity: float) -> SynthesisConfig:
+    """Create bounded Piper synthesis controls from a Dragon profile."""
     intensity = max(0.0, min(1.0, intensity))
     base_noise = float(profile.get("noise_scale", 0.667))
     base_width = float(profile.get("noise_w_scale", 0.8))
-    # Keep profile character bounded. Intensity only nudges variation, never model identity.
     noise_scale = max(0.1, min(1.5, base_noise * (0.9 + 0.2 * intensity)))
     noise_w_scale = max(0.1, min(1.5, base_width * (0.9 + 0.2 * intensity)))
     return SynthesisConfig(
@@ -112,13 +118,25 @@ def _synthesis_config(profile: dict[str, Any], intensity: float) -> SynthesisCon
 
 
 class SpeakRequest(BaseModel):
+    """Bounded local speech request."""
+
     text: str = Field(min_length=1, max_length=MAX_TEXT_CHARS)
     profile: str = "nova_warm"
     intensity: float = Field(default=0.65, ge=0.0, le=1.0)
 
+    @field_validator("text")
+    @classmethod
+    def text_must_not_be_blank(cls, value: str) -> str:
+        """Reject whitespace-only input before synthesis."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("text must contain non-whitespace characters")
+        return stripped
+
 
 @app.get("/health")
 def health() -> dict[str, Any]:
+    """Return non-secret runtime health and truth-boundary markers."""
     profiles: dict[str, Any] = PROFILES["profiles"]
     installed = []
     for name, profile in profiles.items():
@@ -138,6 +156,7 @@ def health() -> dict[str, Any]:
         "v3d_voice_inference_claimed": False,
         "profile_count": len(profiles),
         "default_model_ready": default_path.is_file(),
+        "auth_configured": bool(ACCESS_TOKEN),
         "profiles": installed,
         "paid_api_required": False,
     }
@@ -145,6 +164,7 @@ def health() -> dict[str, Any]:
 
 @app.get("/v1/profiles")
 def list_profiles(authorization: str | None = Header(default=None)) -> dict[str, Any]:
+    """List public profile metadata for an authenticated local client."""
     _require_auth(authorization)
     public_profiles = []
     for name, profile in PROFILES["profiles"].items():
@@ -165,6 +185,7 @@ def list_profiles(authorization: str | None = Header(default=None)) -> dict[str,
 
 @app.post("/v1/speak")
 def speak(request: SpeakRequest, authorization: str | None = Header(default=None)) -> Response:
+    """Generate a local WAV with a bounded Dragon profile."""
     _require_auth(authorization)
     profile_name, profile = _resolve_profile(request.profile)
     voice, model_path, fallback = _get_voice(profile)
@@ -174,7 +195,7 @@ def speak(request: SpeakRequest, authorization: str | None = Header(default=None
     buffer = io.BytesIO()
     with _synthesis_lock:
         with wave.open(buffer, "wb") as wav_file:
-            voice.synthesize_wav(request.text.strip(), wav_file, syn_config=syn_config)
+            voice.synthesize_wav(request.text, wav_file, syn_config=syn_config)
     elapsed_ms = int((time.perf_counter() - started) * 1000)
 
     return Response(

--- a/local-voice/install-pi5.sh
+++ b/local-voice/install-pi5.sh
@@ -6,7 +6,7 @@ APP_HOME="${DRAGON_LOCAL_VOICE_HOME:-$HOME/dragon-local-voice-v1}"
 MODEL_DIR="$APP_HOME/models"
 VENV="$APP_HOME/.venv"
 PORT="${DRAGON_LOCAL_VOICE_PORT:-8123}"
-BOOTSTRAP_VOICE="${DRAGON_BOOTSTRAP_VOICE:-en_US-lessac-medium}"
+BOOTSTRAP_VOICE="en_US-lessac-medium"
 SERVICE_DIR="$HOME/.config/systemd/user"
 SERVICE_FILE="$SERVICE_DIR/dragon-local-voice.service"
 ENV_FILE="$APP_HOME/.env"
@@ -51,7 +51,7 @@ echo "BOOTSTRAP_MODEL=$BOOTSTRAP_VOICE"
 echo 'BOOTSTRAP_MODEL=PASS'
 
 if [ ! -s "$ENV_FILE" ]; then
-  TOKEN="$($VENV/bin/python - <<'PY'
+  TOKEN="$("$VENV/bin/python" - <<'PY'
 import secrets
 print(secrets.token_urlsafe(48))
 PY
@@ -65,6 +65,7 @@ DRAGON_VOICE_MAX_TEXT=1200
 EOF
 fi
 chmod 600 "$ENV_FILE"
+grep -q '^DRAGON_VOICE_TOKEN=.' "$ENV_FILE"
 echo 'LOCAL_SECRET_FILE=PASS'
 
 cat >"$SERVICE_FILE" <<EOF
@@ -104,6 +105,7 @@ done
 
 grep -q '"ok":true' "$APP_HOME/health.json"
 grep -q '"paid_api_required":false' "$APP_HOME/health.json"
+grep -q '"auth_configured":true' "$APP_HOME/health.json"
 echo 'LOCAL_VOICE_HEALTH=PASS'
 
 set -a

--- a/local-voice/install-pi5.sh
+++ b/local-voice/install-pi5.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_HOME="${DRAGON_LOCAL_VOICE_HOME:-$HOME/dragon-local-voice-v1}"
+MODEL_DIR="$APP_HOME/models"
+VENV="$APP_HOME/.venv"
+PORT="${DRAGON_LOCAL_VOICE_PORT:-8123}"
+BOOTSTRAP_VOICE="${DRAGON_BOOTSTRAP_VOICE:-en_US-lessac-medium}"
+SERVICE_DIR="$HOME/.config/systemd/user"
+SERVICE_FILE="$SERVICE_DIR/dragon-local-voice.service"
+ENV_FILE="$APP_HOME/.env"
+
+printf '%s\n' '=== UNIVERSAL DRAGON LOCAL VOICE V1 INSTALL ==='
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo 'PYTHON3=MISS'
+  exit 4
+fi
+
+if command -v sudo >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y python3-venv curl ffmpeg
+else
+  echo 'SUDO=MISS'
+  exit 5
+fi
+
+echo 'SYSTEM_DEPENDENCIES=PASS'
+
+mkdir -p "$APP_HOME" "$MODEL_DIR" "$SERVICE_DIR"
+install -m 0644 "$SOURCE_DIR/dragon_voice_server.py" "$APP_HOME/dragon_voice_server.py"
+install -m 0644 "$SOURCE_DIR/profiles.json" "$APP_HOME/profiles.json"
+install -m 0644 "$SOURCE_DIR/requirements.txt" "$APP_HOME/requirements.txt"
+
+python3 -m venv "$VENV"
+"$VENV/bin/python" -m pip install --upgrade pip setuptools wheel
+"$VENV/bin/python" -m pip install -r "$APP_HOME/requirements.txt"
+echo 'PYTHON_ENV=PASS'
+
+if [ ! -s "$MODEL_DIR/${BOOTSTRAP_VOICE}.onnx" ]; then
+  (
+    cd "$MODEL_DIR"
+    "$VENV/bin/python" -m piper.download_voices "$BOOTSTRAP_VOICE"
+  )
+fi
+
+test -s "$MODEL_DIR/${BOOTSTRAP_VOICE}.onnx"
+test -s "$MODEL_DIR/${BOOTSTRAP_VOICE}.onnx.json"
+echo "BOOTSTRAP_MODEL=$BOOTSTRAP_VOICE"
+echo 'BOOTSTRAP_MODEL=PASS'
+
+if [ ! -s "$ENV_FILE" ]; then
+  TOKEN="$($VENV/bin/python - <<'PY'
+import secrets
+print(secrets.token_urlsafe(48))
+PY
+)"
+  umask 077
+  cat >"$ENV_FILE" <<EOF
+DRAGON_VOICE_TOKEN=$TOKEN
+DRAGON_VOICE_MODEL_DIR=$MODEL_DIR
+DRAGON_VOICE_PROFILES=$APP_HOME/profiles.json
+DRAGON_VOICE_MAX_TEXT=1200
+EOF
+fi
+chmod 600 "$ENV_FILE"
+echo 'LOCAL_SECRET_FILE=PASS'
+
+cat >"$SERVICE_FILE" <<EOF
+[Unit]
+Description=Universal Dragon Local Voice V1
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$APP_HOME
+EnvironmentFile=$ENV_FILE
+ExecStart=$VENV/bin/python -m uvicorn dragon_voice_server:app --app-dir $APP_HOME --host 127.0.0.1 --port $PORT --workers 1
+Restart=on-failure
+RestartSec=3
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=$APP_HOME
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable --now dragon-local-voice.service
+
+echo 'SERVICE_INSTALL=PASS'
+
+for _ in $(seq 1 30); do
+  if curl --silent --fail "http://127.0.0.1:$PORT/health" >"$APP_HOME/health.json"; then
+    break
+  fi
+  sleep 1
+done
+
+grep -q '"ok":true' "$APP_HOME/health.json"
+grep -q '"paid_api_required":false' "$APP_HOME/health.json"
+echo 'LOCAL_VOICE_HEALTH=PASS'
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+curl --silent --show-error --fail \
+  -H "Authorization: Bearer $DRAGON_VOICE_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Universal Dragon local voice is online.","profile":"nova_warm","intensity":0.65}' \
+  "http://127.0.0.1:$PORT/v1/speak" \
+  -o "$APP_HOME/proof.wav"
+
+test -s "$APP_HOME/proof.wav"
+file "$APP_HOME/proof.wav" | grep -qi 'wave audio'
+echo 'LOCAL_WAV_GENERATION=PASS'
+
+echo 'PAID_API_USED=NO'
+echo 'ELEVENLABS_REQUIRED=NO'
+echo 'V3D_TTS_INFERENCE_CLAIMED=NO'
+echo "VOICE_API=http://127.0.0.1:$PORT"
+echo "PROOF_WAV=$APP_HOME/proof.wav"
+echo 'DRAGON_LOCAL_VOICE_V1=PASS'

--- a/local-voice/profiles.json
+++ b/local-voice/profiles.json
@@ -1,0 +1,70 @@
+{
+  "schema": "dragon.local-voice.profiles.v1",
+  "default_profile": "nova_warm",
+  "default_model": "en_US-lessac-medium.onnx",
+  "profiles": {
+    "nova_warm": {
+      "display_name": "NOVA Warm",
+      "character": "warm, clear, reassuring everyday assistant",
+      "model": "dragon-nova-warm.onnx",
+      "volume": 1.0,
+      "length_scale": 1.02,
+      "noise_scale": 0.58,
+      "noise_w_scale": 0.72
+    },
+    "dragon_playful": {
+      "display_name": "Dragon Playful",
+      "character": "smiling, light, teasing, energetic",
+      "model": "dragon-playful.onnx",
+      "volume": 1.0,
+      "length_scale": 0.94,
+      "noise_scale": 0.74,
+      "noise_w_scale": 0.90
+    },
+    "dragon_serious": {
+      "display_name": "Dragon Serious",
+      "character": "firm, controlled, command-ready",
+      "model": "dragon-serious.onnx",
+      "volume": 1.02,
+      "length_scale": 1.08,
+      "noise_scale": 0.45,
+      "noise_w_scale": 0.60
+    },
+    "dragon_deep": {
+      "display_name": "Dragon Deep",
+      "character": "mature, deep, cinematic authority",
+      "model": "dragon-deep.onnx",
+      "volume": 1.03,
+      "length_scale": 1.12,
+      "noise_scale": 0.50,
+      "noise_w_scale": 0.62
+    },
+    "whatsapp_natural": {
+      "display_name": "WhatsApp Natural",
+      "character": "short, conversational, friendly voice-note delivery",
+      "model": "dragon-whatsapp-natural.onnx",
+      "volume": 1.0,
+      "length_scale": 0.98,
+      "noise_scale": 0.60,
+      "noise_w_scale": 0.74
+    },
+    "story_soul": {
+      "display_name": "Story Soul",
+      "character": "expressive storyteller with measured pacing",
+      "model": "dragon-story-soul.onnx",
+      "volume": 1.0,
+      "length_scale": 1.06,
+      "noise_scale": 0.70,
+      "noise_w_scale": 0.86
+    },
+    "night_whisper": {
+      "display_name": "Night Whisper",
+      "character": "soft, low-energy, quiet late-night assistant",
+      "model": "dragon-night-whisper.onnx",
+      "volume": 0.82,
+      "length_scale": 1.14,
+      "noise_scale": 0.42,
+      "noise_w_scale": 0.54
+    }
+  }
+}

--- a/local-voice/requirements.txt
+++ b/local-voice/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115,<1
+uvicorn[standard]>=0.34,<1
+pydantic>=2.10,<3
+piper-tts>=1.4,<2

--- a/local-voice/v2/dragon_voice_v2_server.py
+++ b/local-voice/v2/dragon_voice_v2_server.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import hmac
+import importlib.util
+import io
+import json
+import os
+import threading
+import time
+import urllib.error
+import urllib.request
+import wave
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import FastAPI, Header, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel, Field, field_validator
+
+from voice_soul_v2 import CONTEXTS, MOODS, REACTIONS, plan_voice
+
+APP_DIR = Path(__file__).resolve().parent
+PROFILES_PATH = Path(os.environ.get("DRAGON_V2_PROFILES", APP_DIR / "profiles-v2.json")).expanduser().resolve()
+REFERENCE_DIR = Path(os.environ.get("DRAGON_V2_REFERENCE_DIR", APP_DIR / "references")).expanduser().resolve()
+ACCESS_TOKEN = os.environ.get("DRAGON_VOICE_TOKEN", "")
+V1_URL = os.environ.get("DRAGON_V1_URL", "http://127.0.0.1:8123").rstrip("/")
+MAX_TEXT_CHARS = int(os.environ.get("DRAGON_VOICE_MAX_TEXT", "1200"))
+ALLOW_NANO_WITHOUT_REFERENCE = os.environ.get("DRAGON_V2_ALLOW_NANO_WITHOUT_REFERENCE", "0") == "1"
+
+app = FastAPI(title="Universal Dragon Human Voice Soul", version="2.0.0")
+_engine_lock = threading.Lock()
+_synthesis_lock = threading.Lock()
+_kokoro_model: Any | None = None
+_kokoro_pipelines: dict[str, Any] = {}
+_nano_model: Any | None = None
+
+
+def _authorized(authorization: str | None) -> bool:
+    """Validate the local bearer token and fail closed when it is absent."""
+    if not ACCESS_TOKEN:
+        return False
+    if not authorization or not authorization.lower().startswith("bearer "):
+        return False
+    candidate = authorization.split(" ", 1)[1].strip()
+    return bool(candidate) and hmac.compare_digest(candidate, ACCESS_TOKEN)
+
+
+def _require_auth(authorization: str | None) -> None:
+    """Require a valid local bearer token."""
+    if not _authorized(authorization):
+        raise HTTPException(status_code=401, detail="unauthorized", headers={"WWW-Authenticate": "Bearer"})
+
+
+def _module_ready(name: str) -> bool:
+    """Check whether an optional local engine module is installed without loading it."""
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _reference_path(filename: str) -> Path:
+    """Resolve a local reference WAV without allowing path traversal."""
+    if not filename or Path(filename).name != filename:
+        raise RuntimeError("invalid reference filename")
+    base = REFERENCE_DIR.resolve()
+    path = (base / filename).resolve()
+    if path.parent != base:
+        raise RuntimeError("reference path escaped directory")
+    return path
+
+
+def _pcm16_wav(audio: Any, sample_rate: int) -> bytes:
+    """Convert a mono floating-point tensor/array into a standard PCM16 WAV."""
+    import numpy as np
+
+    if hasattr(audio, "detach"):
+        audio = audio.detach().cpu().numpy()
+    values = np.asarray(audio, dtype=np.float32).reshape(-1)
+    if values.size == 0:
+        raise RuntimeError("engine returned empty audio")
+    values = np.nan_to_num(values, nan=0.0, posinf=1.0, neginf=-1.0)
+    pcm = (np.clip(values, -1.0, 1.0) * 32767.0).astype("<i2")
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(int(sample_rate))
+        wav_file.writeframes(pcm.tobytes())
+    return buffer.getvalue()
+
+
+def _kokoro_engine(plan: dict[str, Any]) -> tuple[bytes, dict[str, str]]:
+    """Synthesize with the lightweight multi-voice Kokoro CPU engine."""
+    global _kokoro_model
+
+    if not _module_ready("kokoro"):
+        raise RuntimeError("kokoro_not_installed")
+
+    from kokoro import KModel, KPipeline
+    import numpy as np
+
+    voice_id = str(plan["kokoro"]["voice"])
+    lang_code = "b" if voice_id.startswith("bf_") or voice_id.startswith("bm_") else "a"
+
+    with _engine_lock:
+        if _kokoro_model is None:
+            _kokoro_model = KModel(repo_id="hexgrad/Kokoro-82M").to("cpu").eval()
+        pipeline = _kokoro_pipelines.get(lang_code)
+        if pipeline is None:
+            pipeline = KPipeline(lang_code=lang_code, repo_id="hexgrad/Kokoro-82M", model=_kokoro_model)
+            _kokoro_pipelines[lang_code] = pipeline
+
+    chunks: list[Any] = []
+    for _, _, audio in pipeline(
+        plan["spoken_text"],
+        voice=voice_id,
+        speed=float(plan["kokoro"]["speed"]),
+    ):
+        if audio is not None:
+            if hasattr(audio, "detach"):
+                audio = audio.detach().cpu().numpy()
+            chunks.append(np.asarray(audio, dtype=np.float32).reshape(-1))
+
+    if not chunks:
+        raise RuntimeError("kokoro_empty_audio")
+
+    joined = np.concatenate(chunks)
+    return _pcm16_wav(joined, 24000), {"voice": voice_id, "reference": "builtin"}
+
+
+def _nano_engine(plan: dict[str, Any]) -> tuple[bytes, dict[str, str]]:
+    """Synthesize with optional Chatterbox Nano and a permitted local reference when available."""
+    global _nano_model
+
+    if not _module_ready("chatterbox"):
+        raise RuntimeError("nano_not_installed")
+
+    from chatterbox.tts_turbo import ChatterboxTurboTTS
+
+    reference_name = str(plan["nano"]["reference_file"])
+    reference = _reference_path(reference_name)
+    use_reference = reference.is_file()
+    if not use_reference and not ALLOW_NANO_WITHOUT_REFERENCE:
+        raise RuntimeError("nano_reference_missing")
+
+    with _engine_lock:
+        if _nano_model is None:
+            _nano_model = ChatterboxTurboTTS.from_pretrained(device="cpu", nano=True)
+        model = _nano_model
+
+    kwargs: dict[str, Any] = {}
+    if use_reference:
+        kwargs["audio_prompt_path"] = str(reference)
+    audio = model.generate(str(plan["nano"]["text"]), **kwargs)
+    return _pcm16_wav(audio, int(model.sr)), {
+        "voice": "reference" if use_reference else "nano-default",
+        "reference": "yes" if use_reference else "no",
+    }
+
+
+def _piper_engine(plan: dict[str, Any]) -> tuple[bytes, dict[str, str]]:
+    """Fall back to the already-proven local Piper V1 service."""
+    if not ACCESS_TOKEN:
+        raise RuntimeError("local_token_missing")
+    payload = json.dumps(
+        {
+            "text": plan["spoken_text"],
+            "profile": plan["piper"]["profile"],
+            "intensity": plan["intensity"],
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"{V1_URL}/v1/speak",
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {ACCESS_TOKEN}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=45) as response:
+            audio = response.read()
+            model = response.headers.get("X-Dragon-Voice-Model", "piper")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"piper_http_{exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError("piper_unreachable") from exc
+    if not audio.startswith(b"RIFF"):
+        raise RuntimeError("piper_invalid_wav")
+    return audio, {"voice": model, "reference": "none"}
+
+
+class SpeakV2Request(BaseModel):
+    """Bounded Human Voice Soul V2 request."""
+
+    text: str = Field(min_length=1, max_length=MAX_TEXT_CHARS)
+    profile: str | None = None
+    mood: str | None = None
+    context: str = "chat"
+    reaction: str | None = None
+    intensity: float = Field(default=0.65, ge=0.0, le=1.0)
+    engine: Literal["auto", "kokoro", "nano", "piper"] = "auto"
+
+    @field_validator("text")
+    @classmethod
+    def non_blank_text(cls, value: str) -> str:
+        """Reject whitespace-only speech text."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("text must contain non-whitespace characters")
+        return stripped
+
+    @field_validator("context")
+    @classmethod
+    def known_context(cls, value: str) -> str:
+        """Normalize unknown contexts to chat rather than permitting arbitrary controls."""
+        normalized = value.strip().lower()
+        return normalized if normalized in CONTEXTS else "chat"
+
+    @field_validator("mood", "reaction")
+    @classmethod
+    def bounded_optional_control(cls, value: str | None, info: Any) -> str | None:
+        """Drop unsupported mood/reaction control names."""
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        allowed = MOODS if info.field_name == "mood" else REACTIONS
+        return normalized if normalized in allowed else None
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    """Report installed engines without loading their neural weights."""
+    references = 0
+    if REFERENCE_DIR.is_dir():
+        references = sum(1 for path in REFERENCE_DIR.glob("*.wav") if path.is_file())
+    return {
+        "ok": True,
+        "schema": "dragon.voice-soul.health.v2",
+        "auth_configured": bool(ACCESS_TOKEN),
+        "kokoro_installed": _module_ready("kokoro"),
+        "nano_installed": _module_ready("chatterbox"),
+        "piper_v1_fallback": V1_URL,
+        "reference_voice_count": references,
+        "profile_count": 7,
+        "paid_api_required": False,
+        "device_claim": "cpu-first",
+        "v3d_tts_inference_claimed": False,
+    }
+
+
+@app.post("/v2/plan")
+def plan_endpoint(request: SpeakV2Request, authorization: str | None = Header(default=None)) -> dict[str, Any]:
+    """Return the sanitized provider-independent execution plan."""
+    _require_auth(authorization)
+    return plan_voice(
+        request.text,
+        profile=request.profile,
+        mood=request.mood,
+        context=request.context,
+        reaction=request.reaction,
+        intensity=request.intensity,
+        profiles_path=PROFILES_PATH,
+    )
+
+
+@app.get("/v2/profiles")
+def profiles_endpoint(authorization: str | None = Header(default=None)) -> dict[str, Any]:
+    """Return the seven non-secret voice identities and reference readiness."""
+    _require_auth(authorization)
+    data = json.loads(PROFILES_PATH.read_text(encoding="utf-8"))
+    result = []
+    for profile_id, profile in data["profiles"].items():
+        reference = _reference_path(str(profile["reference_file"]))
+        result.append(
+            {
+                "id": profile_id,
+                "display_name": profile["display_name"],
+                "persona": profile["persona"],
+                "kokoro_voice": profile["kokoro_voice"],
+                "reference_ready": reference.is_file(),
+            }
+        )
+    return {"schema": "dragon.voice-soul.profile-list.v2", "profiles": result}
+
+
+@app.post("/v2/speak")
+def speak_endpoint(request: SpeakV2Request, authorization: str | None = Header(default=None)) -> Response:
+    """Generate Human Voice Soul audio with truthful engine fallback markers."""
+    _require_auth(authorization)
+    plan = plan_voice(
+        request.text,
+        profile=request.profile,
+        mood=request.mood,
+        context=request.context,
+        reaction=request.reaction,
+        intensity=request.intensity,
+        profiles_path=PROFILES_PATH,
+    )
+
+    requested = request.engine
+    engine_order = [requested] if requested != "auto" else list(plan["engine_order"])
+    engines = {"kokoro": _kokoro_engine, "nano": _nano_engine, "piper": _piper_engine}
+    failures: list[str] = []
+    started = time.perf_counter()
+
+    with _synthesis_lock:
+        for engine_name in engine_order:
+            try:
+                audio, meta = engines[engine_name](plan)
+                elapsed_ms = int((time.perf_counter() - started) * 1000)
+                return Response(
+                    content=audio,
+                    media_type="audio/wav",
+                    headers={
+                        "Cache-Control": "no-store",
+                        "X-Dragon-Voice-Schema": "dragon.voice-soul.v2",
+                        "X-Dragon-Voice-Engine": engine_name,
+                        "X-Dragon-Voice-Profile": str(plan["profile"]),
+                        "X-Dragon-Voice-Mood": str(plan["mood"]),
+                        "X-Dragon-Voice-Reaction": str(plan["reaction"]),
+                        "X-Dragon-Voice-Reference": meta["reference"],
+                        "X-Dragon-Voice-Model": meta["voice"],
+                        "X-Dragon-Engine-Fallback": "yes" if engine_name != engine_order[0] else "no",
+                        "X-Dragon-Inference-Ms": str(elapsed_ms),
+                        "X-Dragon-Paid-API": "no",
+                        "X-Dragon-Device-Claim": "cpu-first",
+                        "X-Dragon-V3D-TTS": "not-claimed",
+                    },
+                )
+            except Exception as exc:
+                failures.append(f"{engine_name}:{type(exc).__name__}")
+                if requested != "auto":
+                    break
+
+    raise HTTPException(
+        status_code=503,
+        detail={"error": "all_local_voice_engines_failed", "engines": failures},
+    )

--- a/local-voice/v2/dragon_voice_v2_server.py
+++ b/local-voice/v2/dragon_voice_v2_server.py
@@ -27,11 +27,8 @@ V1_URL = os.environ.get("DRAGON_V1_URL", "http://127.0.0.1:8123").rstrip("/")
 MAX_TEXT_CHARS = int(os.environ.get("DRAGON_VOICE_MAX_TEXT", "1200"))
 ALLOW_NANO_WITHOUT_REFERENCE = os.environ.get("DRAGON_V2_ALLOW_NANO_WITHOUT_REFERENCE", "0") == "1"
 
-app = FastAPI(title="Universal Dragon Human Voice Soul", version="2.0.0")
-_engine_lock = threading.Lock()
+app = FastAPI(title="Universal Dragon Human Voice Soul", version="2.1.0")
 _synthesis_lock = threading.Lock()
-_kokoro_model: Any | None = None
-_kokoro_pipelines: dict[str, Any] = {}
 _nano_model: Any | None = None
 
 
@@ -91,42 +88,18 @@ def _pcm16_wav(audio: Any, sample_rate: int) -> bytes:
 
 
 def _kokoro_engine(plan: dict[str, Any]) -> tuple[bytes, dict[str, str]]:
-    """Synthesize with the lightweight multi-voice Kokoro CPU engine."""
-    global _kokoro_model
+    """Synthesize with Kokoro KModel and a spaCy-free eSpeak English frontend."""
+    if not _module_ready("kokoro") or not _module_ready("misaki"):
+        raise RuntimeError("kokoro_lite_not_installed")
 
-    if not _module_ready("kokoro"):
-        raise RuntimeError("kokoro_not_installed")
+    from kokoro_pi5_lite import synthesize
 
-    from kokoro import KModel, KPipeline
-    import numpy as np
-
-    voice_id = str(plan["kokoro"]["voice"])
-    lang_code = "b" if voice_id.startswith("bf_") or voice_id.startswith("bm_") else "a"
-
-    with _engine_lock:
-        if _kokoro_model is None:
-            _kokoro_model = KModel(repo_id="hexgrad/Kokoro-82M").to("cpu").eval()
-        pipeline = _kokoro_pipelines.get(lang_code)
-        if pipeline is None:
-            pipeline = KPipeline(lang_code=lang_code, repo_id="hexgrad/Kokoro-82M", model=_kokoro_model)
-            _kokoro_pipelines[lang_code] = pipeline
-
-    chunks: list[Any] = []
-    for _, _, audio in pipeline(
-        plan["spoken_text"],
-        voice=voice_id,
-        speed=float(plan["kokoro"]["speed"]),
-    ):
-        if audio is not None:
-            if hasattr(audio, "detach"):
-                audio = audio.detach().cpu().numpy()
-            chunks.append(np.asarray(audio, dtype=np.float32).reshape(-1))
-
-    if not chunks:
-        raise RuntimeError("kokoro_empty_audio")
-
-    joined = np.concatenate(chunks)
-    return _pcm16_wav(joined, 24000), {"voice": voice_id, "reference": "builtin"}
+    audio, meta = synthesize(
+        str(plan["spoken_text"]),
+        str(plan["kokoro"]["voice"]),
+        float(plan["kokoro"]["speed"]),
+    )
+    return _pcm16_wav(audio, 24000), meta
 
 
 def _nano_engine(plan: dict[str, Any]) -> tuple[bytes, dict[str, str]]:
@@ -144,10 +117,9 @@ def _nano_engine(plan: dict[str, Any]) -> tuple[bytes, dict[str, str]]:
     if not use_reference and not ALLOW_NANO_WITHOUT_REFERENCE:
         raise RuntimeError("nano_reference_missing")
 
-    with _engine_lock:
-        if _nano_model is None:
-            _nano_model = ChatterboxTurboTTS.from_pretrained(device="cpu", nano=True)
-        model = _nano_model
+    if _nano_model is None:
+        _nano_model = ChatterboxTurboTTS.from_pretrained(device="cpu", nano=True)
+    model = _nano_model
 
     kwargs: dict[str, Any] = {}
     if use_reference:
@@ -240,7 +212,8 @@ def health() -> dict[str, Any]:
         "ok": True,
         "schema": "dragon.voice-soul.health.v2",
         "auth_configured": bool(ACCESS_TOKEN),
-        "kokoro_installed": _module_ready("kokoro"),
+        "kokoro_installed": _module_ready("kokoro") and _module_ready("misaki"),
+        "kokoro_frontend": "espeak-spacy-free",
         "nano_installed": _module_ready("chatterbox"),
         "piper_v1_fallback": V1_URL,
         "reference_voice_count": references,
@@ -323,6 +296,7 @@ def speak_endpoint(request: SpeakV2Request, authorization: str | None = Header(d
                         "X-Dragon-Voice-Reaction": str(plan["reaction"]),
                         "X-Dragon-Voice-Reference": meta["reference"],
                         "X-Dragon-Voice-Model": meta["voice"],
+                        "X-Dragon-Voice-G2P": meta.get("g2p", "n/a"),
                         "X-Dragon-Engine-Fallback": "yes" if engine_name != engine_order[0] else "no",
                         "X-Dragon-Inference-Ms": str(elapsed_ms),
                         "X-Dragon-Paid-API": "no",

--- a/local-voice/v2/install-nano-pi5.sh
+++ b/local-voice/v2/install-nano-pi5.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+V2_HOME="${DRAGON_LOCAL_VOICE_V2_HOME:-$HOME/dragon-local-voice-v2}"
+VENV="$V2_HOME/.venv"
+REQ="$V2_HOME/requirements-nano.txt"
+
+printf '%s\n' '=== UNIVERSAL DRAGON CHATTERBOX NANO INSTALL ==='
+
+if [ ! -x "$VENV/bin/python" ] || [ ! -s "$REQ" ]; then
+  echo 'HUMAN_VOICE_V2_BASE=MISS'
+  exit 4
+fi
+
+"$VENV/bin/python" -m pip install --prefer-binary -r "$REQ"
+"$VENV/bin/python" - <<'PY'
+from chatterbox.tts_turbo import ChatterboxTurboTTS
+print("CHATTERBOX_NANO_IMPORT=PASS")
+PY
+
+systemctl --user restart dragon-local-voice-v2.service
+for _ in $(seq 1 45); do
+  if curl --silent --fail http://127.0.0.1:8124/health >"$V2_HOME/nano-health.json"; then
+    break
+  fi
+  sleep 1
+done
+
+grep -q '"nano_installed":true' "$V2_HOME/nano-health.json"
+echo 'CHATTERBOX_NANO_INSTALL=PASS'
+echo 'NANO_REFERENCE_POLICY=LOCAL_PERMISSIONED_WAV_ONLY'
+echo 'NANO_AUDIO_PROOF=REQUIRES_REFERENCE_OR_EXPLICIT_TEST_MODE'
+echo 'PAID_API_USED=NO'
+echo 'V3D_TTS_INFERENCE_CLAIMED=NO'

--- a/local-voice/v2/install-v2-pi5.sh
+++ b/local-voice/v2/install-v2-pi5.sh
@@ -12,6 +12,9 @@ SERVICE_FILE="$SERVICE_DIR/dragon-local-voice-v2.service"
 CONFIG_ENV="$V2_HOME/runtime.env"
 REFERENCE_DIR="$V2_HOME/references"
 CACHE_DIR="$V2_HOME/cache"
+ENV_MARKER="$V2_HOME/.kokoro-pi5-lite-v1"
+KOKORO_SHA="dfb907a02bba8152ca444717ca5d78747ccb4bec"
+MISAKI_SHA="fba1236595f2d2bf21d414ba6e57d25256afada3"
 
 printf '%s\n' '=== UNIVERSAL DRAGON HUMAN VOICE SOUL V2 INSTALL ==='
 
@@ -41,20 +44,60 @@ echo 'V2_SYSTEM_DEPENDENCIES=PASS'
 mkdir -p "$V2_HOME" "$REFERENCE_DIR" "$CACHE_DIR/huggingface" "$CACHE_DIR/torch" "$SERVICE_DIR"
 install -m 0644 "$SOURCE_DIR/dragon_voice_v2_server.py" "$V2_HOME/dragon_voice_v2_server.py"
 install -m 0644 "$SOURCE_DIR/voice_soul_v2.py" "$V2_HOME/voice_soul_v2.py"
+install -m 0644 "$SOURCE_DIR/kokoro_pi5_lite.py" "$V2_HOME/kokoro_pi5_lite.py"
 install -m 0644 "$SOURCE_DIR/profiles-v2.json" "$V2_HOME/profiles-v2.json"
 install -m 0644 "$SOURCE_DIR/requirements-v2.txt" "$V2_HOME/requirements-v2.txt"
 install -m 0644 "$SOURCE_DIR/requirements-nano.txt" "$V2_HOME/requirements-nano.txt"
 
 test -s "$V2_HOME/dragon_voice_v2_server.py"
+test -s "$V2_HOME/kokoro_pi5_lite.py"
 test -s "$V2_HOME/profiles-v2.json"
 echo 'V2_RUNTIME_FILES=PASS'
 
-python3 -m venv "$VENV"
-"$VENV/bin/python" -m pip install --upgrade pip setuptools wheel
-"$VENV/bin/python" -m pip install --prefer-binary -r "$V2_HOME/requirements-v2.txt"
+EXPECTED_MARKER="kokoro=$KOKORO_SHA misaki=$MISAKI_SHA frontend=espeak-spacy-free"
+CURRENT_MARKER="$(cat "$ENV_MARKER" 2>/dev/null || true)"
+if [ "$CURRENT_MARKER" != "$EXPECTED_MARKER" ]; then
+  echo 'V2_ENV_REBUILD=YES'
+  systemctl --user stop dragon-local-voice-v2.service 2>/dev/null || true
+  rm -rf "$VENV"
+  python3 -m venv "$VENV"
+  "$VENV/bin/python" -m pip install --upgrade pip setuptools wheel
+  "$VENV/bin/python" -m pip install --prefer-binary -r "$V2_HOME/requirements-v2.txt"
+
+  "$VENV/bin/python" -m pip install --no-deps \
+    "https://github.com/hexgrad/misaki/archive/${MISAKI_SHA}.tar.gz"
+  "$VENV/bin/python" -m pip install --no-deps \
+    "https://github.com/hexgrad/kokoro/archive/${KOKORO_SHA}.tar.gz"
+
+  SITE_PACKAGES="$("$VENV/bin/python" - <<'PY'
+import site
+print(site.getsitepackages()[0])
+PY
+)"
+  KOKORO_INIT="$SITE_PACKAGES/kokoro/__init__.py"
+  test -f "$KOKORO_INIT"
+  cat >"$KOKORO_INIT" <<'PY'
+__version__ = '0.9.4-pi5-lite'
+from .model import KModel
+__all__ = ['KModel']
+PY
+
+  printf '%s\n' "$EXPECTED_MARKER" >"$ENV_MARKER"
+else
+  echo 'V2_ENV_REBUILD=NO'
+fi
+
 "$VENV/bin/python" - <<'PY'
-from kokoro import KModel, KPipeline
-print("KOKORO_IMPORT=PASS")
+import importlib.util
+from kokoro.model import KModel
+from misaki.espeak import EspeakFallback
+import kokoro_pi5_lite
+assert importlib.util.find_spec('kokoro') is not None
+assert importlib.util.find_spec('misaki') is not None
+print('KOKORO_MODEL_IMPORT=PASS')
+print('ESPEAK_G2P_IMPORT=PASS')
+print('SPACY_REQUIRED=NO')
+print('KOKORO_PI5_LITE_ENV=PASS')
 PY
 echo 'KOKORO_V2_ENV=PASS'
 
@@ -100,7 +143,7 @@ systemctl --user daemon-reload
 systemctl --user enable --now dragon-local-voice-v2.service
 echo 'V2_SERVICE_INSTALL=PASS'
 
-for _ in $(seq 1 45); do
+for _ in $(seq 1 60); do
   if curl --silent --fail "http://127.0.0.1:$PORT/health" >"$V2_HOME/health.json"; then
     break
   fi
@@ -111,6 +154,7 @@ test -s "$V2_HOME/health.json"
 grep -q '"ok":true' "$V2_HOME/health.json"
 grep -q '"auth_configured":true' "$V2_HOME/health.json"
 grep -q '"kokoro_installed":true' "$V2_HOME/health.json"
+grep -q '"kokoro_frontend":"espeak-spacy-free"' "$V2_HOME/health.json"
 grep -q '"paid_api_required":false' "$V2_HOME/health.json"
 echo 'HUMAN_VOICE_V2_HEALTH=PASS'
 
@@ -130,7 +174,7 @@ grep -q '"schema":"dragon.voice-soul.v2"' "$V2_HOME/plan-proof.json"
 grep -q '"profile":"whatsapp_natural"' "$V2_HOME/plan-proof.json"
 echo 'HUMAN_VOICE_SOUL_V2_PLAN=PASS'
 
-curl --silent --show-error --fail --max-time 900 \
+curl --silent --show-error --fail --max-time 1200 \
   -D "$V2_HOME/kokoro-proof.headers" \
   -H "Authorization: Bearer $DRAGON_VOICE_TOKEN" \
   -H 'Content-Type: application/json' \
@@ -141,6 +185,7 @@ curl --silent --show-error --fail --max-time 900 \
 test -s "$V2_HOME/kokoro-proof.wav"
 file "$V2_HOME/kokoro-proof.wav" | grep -qi 'wave audio'
 grep -qi '^X-Dragon-Voice-Engine: kokoro' "$V2_HOME/kokoro-proof.headers"
+grep -qi '^X-Dragon-Voice-G2P: espeak-spacy-free' "$V2_HOME/kokoro-proof.headers"
 grep -qi '^X-Dragon-Paid-API: no' "$V2_HOME/kokoro-proof.headers"
 echo 'KOKORO_V2_WAV=PASS'
 

--- a/local-voice/v2/install-v2-pi5.sh
+++ b/local-voice/v2/install-v2-pi5.sh
@@ -49,6 +49,7 @@ export PIP_CACHE_DIR
 export HF_HOME="$CACHE_DIR/huggingface"
 export TORCH_HOME="$CACHE_DIR/torch"
 export XDG_CACHE_HOME="$CACHE_DIR"
+export PYTHONPATH="$V2_HOME${PYTHONPATH:+:$PYTHONPATH}"
 
 install -m 0644 "$SOURCE_DIR/dragon_voice_v2_server.py" "$V2_HOME/dragon_voice_v2_server.py"
 install -m 0644 "$SOURCE_DIR/voice_soul_v2.py" "$V2_HOME/voice_soul_v2.py"
@@ -66,9 +67,24 @@ echo "V2_CACHE_DIR=$CACHE_DIR"
 
 EXPECTED_MARKER="kokoro=$KOKORO_SHA misaki=$MISAKI_SHA frontend=espeak-spacy-free torch=$TORCH_VERSION"
 CURRENT_MARKER="$(cat "$ENV_MARKER" 2>/dev/null || true)"
-if [ "$CURRENT_MARKER" != "$EXPECTED_MARKER" ]; then
+ENV_OK=0
+if [ "$CURRENT_MARKER" = "$EXPECTED_MARKER" ] && [ -x "$VENV/bin/python" ]; then
+  if PYTHONPATH="$V2_HOME" "$VENV/bin/python" - <<'PY' >/dev/null 2>&1
+import torch
+from kokoro.model import KModel
+from misaki.espeak import EspeakFallback
+import kokoro_pi5_lite
+assert torch.version.cuda is None
+PY
+  then
+    ENV_OK=1
+  fi
+fi
+
+if [ "$ENV_OK" -ne 1 ]; then
   echo 'V2_ENV_REBUILD=YES'
   systemctl --user stop dragon-local-voice-v2.service 2>/dev/null || true
+  rm -f "$ENV_MARKER"
   rm -rf "$VENV"
   python3 -m venv "$VENV"
   "$VENV/bin/python" -m pip install --upgrade pip setuptools wheel
@@ -104,12 +120,22 @@ from .model import KModel
 __all__ = ['KModel']
 PY
 
+  PYTHONPATH="$V2_HOME" "$VENV/bin/python" - <<'PY'
+import torch
+from kokoro.model import KModel
+from misaki.espeak import EspeakFallback
+import kokoro_pi5_lite
+assert torch.version.cuda is None
+print('V2_ENV_POSTINSTALL_SANITY=PASS')
+PY
+
   printf '%s\n' "$EXPECTED_MARKER" >"$ENV_MARKER"
 else
   echo 'V2_ENV_REBUILD=NO'
+  echo 'V2_ENV_SANITY=PASS'
 fi
 
-"$VENV/bin/python" - <<'PY'
+PYTHONPATH="$V2_HOME" "$VENV/bin/python" - <<'PY'
 import importlib.util
 import torch
 from kokoro.model import KModel
@@ -120,6 +146,7 @@ assert importlib.util.find_spec('misaki') is not None
 assert torch.version.cuda is None
 print('KOKORO_MODEL_IMPORT=PASS')
 print('ESPEAK_G2P_IMPORT=PASS')
+print('KOKORO_PI5_LITE_IMPORT=PASS')
 print('SPACY_REQUIRED=NO')
 print('CUDA_DEPENDENCY_REQUIRED=NO')
 print('KOKORO_PI5_LITE_ENV=PASS')
@@ -136,6 +163,7 @@ PIP_CACHE_DIR=$PIP_CACHE_DIR
 HF_HOME=$CACHE_DIR/huggingface
 TORCH_HOME=$CACHE_DIR/torch
 XDG_CACHE_HOME=$CACHE_DIR
+PYTHONPATH=$V2_HOME
 EOF
 chmod 600 "$CONFIG_ENV"
 echo 'V2_LOCAL_CONFIG=PASS'

--- a/local-voice/v2/install-v2-pi5.sh
+++ b/local-voice/v2/install-v2-pi5.sh
@@ -12,9 +12,11 @@ SERVICE_FILE="$SERVICE_DIR/dragon-local-voice-v2.service"
 CONFIG_ENV="$V2_HOME/runtime.env"
 REFERENCE_DIR="$V2_HOME/references"
 CACHE_DIR="$V2_HOME/cache"
-ENV_MARKER="$V2_HOME/.kokoro-pi5-lite-v1"
+ENV_MARKER="$V2_HOME/.kokoro-pi5-lite-v2"
 KOKORO_SHA="dfb907a02bba8152ca444717ca5d78747ccb4bec"
 MISAKI_SHA="fba1236595f2d2bf21d414ba6e57d25256afada3"
+TORCH_VERSION="2.13.0+cpu"
+TORCH_CPU_INDEX="https://download.pytorch.org/whl/cpu"
 
 printf '%s\n' '=== UNIVERSAL DRAGON HUMAN VOICE SOUL V2 INSTALL ==='
 
@@ -54,7 +56,7 @@ test -s "$V2_HOME/kokoro_pi5_lite.py"
 test -s "$V2_HOME/profiles-v2.json"
 echo 'V2_RUNTIME_FILES=PASS'
 
-EXPECTED_MARKER="kokoro=$KOKORO_SHA misaki=$MISAKI_SHA frontend=espeak-spacy-free"
+EXPECTED_MARKER="kokoro=$KOKORO_SHA misaki=$MISAKI_SHA frontend=espeak-spacy-free torch=$TORCH_VERSION"
 CURRENT_MARKER="$(cat "$ENV_MARKER" 2>/dev/null || true)"
 if [ "$CURRENT_MARKER" != "$EXPECTED_MARKER" ]; then
   echo 'V2_ENV_REBUILD=YES'
@@ -62,6 +64,18 @@ if [ "$CURRENT_MARKER" != "$EXPECTED_MARKER" ]; then
   rm -rf "$VENV"
   python3 -m venv "$VENV"
   "$VENV/bin/python" -m pip install --upgrade pip setuptools wheel
+
+  "$VENV/bin/python" -m pip install \
+    --index-url "$TORCH_CPU_INDEX" \
+    "torch==$TORCH_VERSION"
+
+  "$VENV/bin/python" - <<'PY'
+import torch
+assert torch.version.cuda is None, torch.version.cuda
+print(f"TORCH_VERSION={torch.__version__}")
+print("TORCH_CPU_ONLY=PASS")
+PY
+
   "$VENV/bin/python" -m pip install --prefer-binary -r "$V2_HOME/requirements-v2.txt"
 
   "$VENV/bin/python" -m pip install --no-deps \
@@ -89,14 +103,17 @@ fi
 
 "$VENV/bin/python" - <<'PY'
 import importlib.util
+import torch
 from kokoro.model import KModel
 from misaki.espeak import EspeakFallback
 import kokoro_pi5_lite
 assert importlib.util.find_spec('kokoro') is not None
 assert importlib.util.find_spec('misaki') is not None
+assert torch.version.cuda is None
 print('KOKORO_MODEL_IMPORT=PASS')
 print('ESPEAK_G2P_IMPORT=PASS')
 print('SPACY_REQUIRED=NO')
+print('CUDA_DEPENDENCY_REQUIRED=NO')
 print('KOKORO_PI5_LITE_ENV=PASS')
 PY
 echo 'KOKORO_V2_ENV=PASS'

--- a/local-voice/v2/install-v2-pi5.sh
+++ b/local-voice/v2/install-v2-pi5.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+V1_HOME="${DRAGON_LOCAL_VOICE_HOME:-$HOME/dragon-local-voice-v1}"
+V1_ENV="$V1_HOME/.env"
+V2_HOME="${DRAGON_LOCAL_VOICE_V2_HOME:-$HOME/dragon-local-voice-v2}"
+VENV="$V2_HOME/.venv"
+PORT="${DRAGON_LOCAL_VOICE_V2_PORT:-8124}"
+SERVICE_DIR="$HOME/.config/systemd/user"
+SERVICE_FILE="$SERVICE_DIR/dragon-local-voice-v2.service"
+CONFIG_ENV="$V2_HOME/runtime.env"
+REFERENCE_DIR="$V2_HOME/references"
+CACHE_DIR="$V2_HOME/cache"
+
+printf '%s\n' '=== UNIVERSAL DRAGON HUMAN VOICE SOUL V2 INSTALL ==='
+
+if [ ! -s "$V1_ENV" ]; then
+  echo 'V1_SECRET_ENV=MISS'
+  exit 4
+fi
+if ! grep -q '^DRAGON_VOICE_TOKEN=.' "$V1_ENV"; then
+  echo 'V1_TOKEN=MISS'
+  exit 5
+fi
+if ! systemctl --user is-active --quiet dragon-local-voice.service; then
+  echo 'V1_SERVICE_ACTIVE=NO'
+  exit 6
+fi
+echo 'V1_PROVEN_FALLBACK=PASS'
+
+if ! command -v sudo >/dev/null 2>&1; then
+  echo 'SUDO=MISS'
+  exit 7
+fi
+
+sudo apt-get update
+sudo apt-get install -y python3-venv curl ffmpeg espeak-ng libsndfile1
+echo 'V2_SYSTEM_DEPENDENCIES=PASS'
+
+mkdir -p "$V2_HOME" "$REFERENCE_DIR" "$CACHE_DIR/huggingface" "$CACHE_DIR/torch" "$SERVICE_DIR"
+install -m 0644 "$SOURCE_DIR/dragon_voice_v2_server.py" "$V2_HOME/dragon_voice_v2_server.py"
+install -m 0644 "$SOURCE_DIR/voice_soul_v2.py" "$V2_HOME/voice_soul_v2.py"
+install -m 0644 "$SOURCE_DIR/profiles-v2.json" "$V2_HOME/profiles-v2.json"
+install -m 0644 "$SOURCE_DIR/requirements-v2.txt" "$V2_HOME/requirements-v2.txt"
+install -m 0644 "$SOURCE_DIR/requirements-nano.txt" "$V2_HOME/requirements-nano.txt"
+
+test -s "$V2_HOME/dragon_voice_v2_server.py"
+test -s "$V2_HOME/profiles-v2.json"
+echo 'V2_RUNTIME_FILES=PASS'
+
+python3 -m venv "$VENV"
+"$VENV/bin/python" -m pip install --upgrade pip setuptools wheel
+"$VENV/bin/python" -m pip install --prefer-binary -r "$V2_HOME/requirements-v2.txt"
+"$VENV/bin/python" - <<'PY'
+from kokoro import KModel, KPipeline
+print("KOKORO_IMPORT=PASS")
+PY
+echo 'KOKORO_V2_ENV=PASS'
+
+cat >"$CONFIG_ENV" <<EOF
+DRAGON_V2_PROFILES=$V2_HOME/profiles-v2.json
+DRAGON_V2_REFERENCE_DIR=$REFERENCE_DIR
+DRAGON_V1_URL=http://127.0.0.1:8123
+DRAGON_VOICE_MAX_TEXT=1200
+DRAGON_V2_ALLOW_NANO_WITHOUT_REFERENCE=0
+HF_HOME=$CACHE_DIR/huggingface
+TORCH_HOME=$CACHE_DIR/torch
+XDG_CACHE_HOME=$CACHE_DIR
+EOF
+chmod 600 "$CONFIG_ENV"
+echo 'V2_LOCAL_CONFIG=PASS'
+
+cat >"$SERVICE_FILE" <<EOF
+[Unit]
+Description=Universal Dragon Human Voice Soul V2
+After=network-online.target dragon-local-voice.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$V2_HOME
+EnvironmentFile=$V1_ENV
+EnvironmentFile=$CONFIG_ENV
+ExecStart=$VENV/bin/python -m uvicorn dragon_voice_v2_server:app --app-dir $V2_HOME --host 127.0.0.1 --port $PORT --workers 1
+Restart=on-failure
+RestartSec=4
+TimeoutStopSec=20
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=$V2_HOME
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable --now dragon-local-voice-v2.service
+echo 'V2_SERVICE_INSTALL=PASS'
+
+for _ in $(seq 1 45); do
+  if curl --silent --fail "http://127.0.0.1:$PORT/health" >"$V2_HOME/health.json"; then
+    break
+  fi
+  sleep 1
+done
+
+test -s "$V2_HOME/health.json"
+grep -q '"ok":true' "$V2_HOME/health.json"
+grep -q '"auth_configured":true' "$V2_HOME/health.json"
+grep -q '"kokoro_installed":true' "$V2_HOME/health.json"
+grep -q '"paid_api_required":false' "$V2_HOME/health.json"
+echo 'HUMAN_VOICE_V2_HEALTH=PASS'
+
+set -a
+# shellcheck disable=SC1090
+source "$V1_ENV"
+set +a
+
+curl --silent --show-error --fail --max-time 60 \
+  -H "Authorization: Bearer $DRAGON_VOICE_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Bro, Human Voice Soul planning is online.","context":"whatsapp","mood":"smile","engine":"auto"}' \
+  "http://127.0.0.1:$PORT/v2/plan" \
+  -o "$V2_HOME/plan-proof.json"
+
+grep -q '"schema":"dragon.voice-soul.v2"' "$V2_HOME/plan-proof.json"
+grep -q '"profile":"whatsapp_natural"' "$V2_HOME/plan-proof.json"
+echo 'HUMAN_VOICE_SOUL_V2_PLAN=PASS'
+
+curl --silent --show-error --fail --max-time 900 \
+  -D "$V2_HOME/kokoro-proof.headers" \
+  -H "Authorization: Bearer $DRAGON_VOICE_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Universal Dragon Human Voice Soul is online.","profile":"nova_warm","mood":"smile","context":"chat","engine":"kokoro"}' \
+  "http://127.0.0.1:$PORT/v2/speak" \
+  -o "$V2_HOME/kokoro-proof.wav"
+
+test -s "$V2_HOME/kokoro-proof.wav"
+file "$V2_HOME/kokoro-proof.wav" | grep -qi 'wave audio'
+grep -qi '^X-Dragon-Voice-Engine: kokoro' "$V2_HOME/kokoro-proof.headers"
+grep -qi '^X-Dragon-Paid-API: no' "$V2_HOME/kokoro-proof.headers"
+echo 'KOKORO_V2_WAV=PASS'
+
+echo 'NANO_ENGINE_CODE=INCLUDED'
+echo 'NANO_RUNTIME_INSTALL=SEPARATE_BOUNDED_STEP'
+echo 'PAID_API_USED=NO'
+echo 'ELEVENLABS_REQUIRED=NO'
+echo 'V3D_TTS_INFERENCE_CLAIMED=NO'
+echo "V2_VOICE_API=http://127.0.0.1:$PORT"
+echo "V2_PROOF_WAV=$V2_HOME/kokoro-proof.wav"
+echo 'DRAGON_HUMAN_VOICE_SOUL_V2=PASS'

--- a/local-voice/v2/install-v2-pi5.sh
+++ b/local-voice/v2/install-v2-pi5.sh
@@ -12,6 +12,7 @@ SERVICE_FILE="$SERVICE_DIR/dragon-local-voice-v2.service"
 CONFIG_ENV="$V2_HOME/runtime.env"
 REFERENCE_DIR="$V2_HOME/references"
 CACHE_DIR="$V2_HOME/cache"
+PIP_CACHE_DIR="$CACHE_DIR/pip"
 ENV_MARKER="$V2_HOME/.kokoro-pi5-lite-v2"
 KOKORO_SHA="dfb907a02bba8152ca444717ca5d78747ccb4bec"
 MISAKI_SHA="fba1236595f2d2bf21d414ba6e57d25256afada3"
@@ -43,7 +44,12 @@ sudo apt-get update
 sudo apt-get install -y python3-venv curl ffmpeg espeak-ng libsndfile1
 echo 'V2_SYSTEM_DEPENDENCIES=PASS'
 
-mkdir -p "$V2_HOME" "$REFERENCE_DIR" "$CACHE_DIR/huggingface" "$CACHE_DIR/torch" "$SERVICE_DIR"
+mkdir -p "$V2_HOME" "$REFERENCE_DIR" "$CACHE_DIR/huggingface" "$CACHE_DIR/torch" "$PIP_CACHE_DIR" "$SERVICE_DIR"
+export PIP_CACHE_DIR
+export HF_HOME="$CACHE_DIR/huggingface"
+export TORCH_HOME="$CACHE_DIR/torch"
+export XDG_CACHE_HOME="$CACHE_DIR"
+
 install -m 0644 "$SOURCE_DIR/dragon_voice_v2_server.py" "$V2_HOME/dragon_voice_v2_server.py"
 install -m 0644 "$SOURCE_DIR/voice_soul_v2.py" "$V2_HOME/voice_soul_v2.py"
 install -m 0644 "$SOURCE_DIR/kokoro_pi5_lite.py" "$V2_HOME/kokoro_pi5_lite.py"
@@ -55,6 +61,8 @@ test -s "$V2_HOME/dragon_voice_v2_server.py"
 test -s "$V2_HOME/kokoro_pi5_lite.py"
 test -s "$V2_HOME/profiles-v2.json"
 echo 'V2_RUNTIME_FILES=PASS'
+echo "V2_HOME=$V2_HOME"
+echo "V2_CACHE_DIR=$CACHE_DIR"
 
 EXPECTED_MARKER="kokoro=$KOKORO_SHA misaki=$MISAKI_SHA frontend=espeak-spacy-free torch=$TORCH_VERSION"
 CURRENT_MARKER="$(cat "$ENV_MARKER" 2>/dev/null || true)"
@@ -124,6 +132,7 @@ DRAGON_V2_REFERENCE_DIR=$REFERENCE_DIR
 DRAGON_V1_URL=http://127.0.0.1:8123
 DRAGON_VOICE_MAX_TEXT=1200
 DRAGON_V2_ALLOW_NANO_WITHOUT_REFERENCE=0
+PIP_CACHE_DIR=$PIP_CACHE_DIR
 HF_HOME=$CACHE_DIR/huggingface
 TORCH_HOME=$CACHE_DIR/torch
 XDG_CACHE_HOME=$CACHE_DIR
@@ -142,6 +151,7 @@ Type=simple
 WorkingDirectory=$V2_HOME
 EnvironmentFile=$V1_ENV
 EnvironmentFile=$CONFIG_ENV
+ExecStartPre=/usr/bin/test -d $V2_HOME
 ExecStart=$VENV/bin/python -m uvicorn dragon_voice_v2_server:app --app-dir $V2_HOME --host 127.0.0.1 --port $PORT --workers 1
 Restart=on-failure
 RestartSec=4

--- a/local-voice/v2/kokoro_pi5_lite.py
+++ b/local-voice/v2/kokoro_pi5_lite.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import torch
+from huggingface_hub import hf_hub_download
+from kokoro.model import KModel
+from misaki.espeak import EspeakFallback
+
+_REPO_ID = "hexgrad/Kokoro-82M"
+_model: KModel | None = None
+_voice_packs: dict[str, torch.Tensor] = {}
+_g2p: dict[bool, EspeakFallback] = {}
+_lock = threading.Lock()
+
+
+def _chunks(text: str, limit: int = 220) -> list[str]:
+    """Split bounded text into small chunks so raw phonemes stay under model limits."""
+    words = text.split()
+    out: list[str] = []
+    current: list[str] = []
+    size = 0
+    for word in words:
+        extra = len(word) + (1 if current else 0)
+        if current and size + extra > limit:
+            out.append(" ".join(current))
+            current = [word]
+            size = len(word)
+        else:
+            current.append(word)
+            size += extra
+    if current:
+        out.append(" ".join(current))
+    return out
+
+
+def _get_model() -> KModel:
+    global _model
+    with _lock:
+        if _model is None:
+            _model = KModel(repo_id=_REPO_ID).to("cpu").eval()
+        return _model
+
+
+def _get_voice_pack(voice_id: str) -> torch.Tensor:
+    with _lock:
+        pack = _voice_packs.get(voice_id)
+        if pack is None:
+            path = hf_hub_download(repo_id=_REPO_ID, filename=f"voices/{voice_id}.pt")
+            pack = torch.load(path, map_location="cpu", weights_only=True)
+            _voice_packs[voice_id] = pack
+        return pack
+
+
+def _get_g2p(british: bool) -> EspeakFallback:
+    with _lock:
+        g2p = _g2p.get(british)
+        if g2p is None:
+            g2p = EspeakFallback(british=british)
+            _g2p[british] = g2p
+        return g2p
+
+
+def synthesize(text: str, voice_id: str, speed: float) -> tuple[np.ndarray, dict[str, str]]:
+    """Run Kokoro KModel with spaCy-free eSpeak English phonemes on CPU."""
+    british = voice_id.startswith("bf_") or voice_id.startswith("bm_")
+    model = _get_model()
+    pack = _get_voice_pack(voice_id)
+    g2p = _get_g2p(british)
+
+    pieces: list[np.ndarray] = []
+    for chunk in _chunks(text):
+        phonemes, _ = g2p(SimpleNamespace(text=chunk))
+        phonemes = (phonemes or "").strip()
+        if not phonemes:
+            continue
+        if len(phonemes) > 500:
+            raise RuntimeError("kokoro_phoneme_chunk_too_long")
+
+        style_index = min(max(len(phonemes) - 1, 0), int(pack.shape[0]) - 1)
+        audio = model(phonemes, pack[style_index], speed=float(speed))
+        values = audio.detach().cpu().numpy().astype(np.float32, copy=False).reshape(-1)
+        if values.size:
+            pieces.append(values)
+            pieces.append(np.zeros(1440, dtype=np.float32))  # 60 ms at 24 kHz
+
+    if not pieces:
+        raise RuntimeError("kokoro_empty_audio")
+
+    joined = np.concatenate(pieces[:-1] if len(pieces) > 1 else pieces)
+    return joined, {
+        "voice": voice_id,
+        "reference": "builtin",
+        "g2p": "espeak-spacy-free",
+    }

--- a/local-voice/v2/profiles-v2.json
+++ b/local-voice/v2/profiles-v2.json
@@ -1,0 +1,69 @@
+{
+  "schema": "dragon.voice-soul.profiles.v2",
+  "default_profile": "nova_warm",
+  "profiles": {
+    "nova_warm": {
+      "display_name": "NOVA Warm",
+      "persona": "warm adult assistant, clear and reassuring",
+      "kokoro_voice": "af_nova",
+      "kokoro_speed": 0.98,
+      "piper_profile": "nova_warm",
+      "reference_file": "nova_warm.wav",
+      "default_mood": "neutral"
+    },
+    "dragon_playful": {
+      "display_name": "Dragon Playful",
+      "persona": "young-adult-like playful energy, smiling and quick",
+      "kokoro_voice": "af_bella",
+      "kokoro_speed": 1.04,
+      "piper_profile": "dragon_playful",
+      "reference_file": "dragon_playful.wav",
+      "default_mood": "smile"
+    },
+    "dragon_serious": {
+      "display_name": "Dragon Serious",
+      "persona": "firm controlled command voice",
+      "kokoro_voice": "am_onyx",
+      "kokoro_speed": 0.92,
+      "piper_profile": "dragon_serious",
+      "reference_file": "dragon_serious.wav",
+      "default_mood": "serious"
+    },
+    "dragon_deep": {
+      "display_name": "Dragon Deep",
+      "persona": "mature cinematic authority",
+      "kokoro_voice": "am_fenrir",
+      "kokoro_speed": 0.88,
+      "piper_profile": "dragon_deep",
+      "reference_file": "dragon_deep.wav",
+      "default_mood": "confident"
+    },
+    "whatsapp_natural": {
+      "display_name": "WhatsApp Natural",
+      "persona": "casual human voice-note delivery with short natural phrasing",
+      "kokoro_voice": "af_sarah",
+      "kokoro_speed": 1.02,
+      "piper_profile": "whatsapp_natural",
+      "reference_file": "whatsapp_natural.wav",
+      "default_mood": "neutral"
+    },
+    "story_soul": {
+      "display_name": "Story Soul",
+      "persona": "measured storyteller with dramatic pacing",
+      "kokoro_voice": "bm_fable",
+      "kokoro_speed": 0.94,
+      "piper_profile": "story_soul",
+      "reference_file": "story_soul.wav",
+      "default_mood": "curious"
+    },
+    "night_whisper": {
+      "display_name": "Night Whisper",
+      "persona": "soft low-energy late-night presence",
+      "kokoro_voice": "bf_lily",
+      "kokoro_speed": 0.86,
+      "piper_profile": "night_whisper",
+      "reference_file": "night_whisper.wav",
+      "default_mood": "whisper"
+    }
+  }
+}

--- a/local-voice/v2/proof-seven-voices.sh
+++ b/local-voice/v2/proof-seven-voices.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+V1_HOME="${DRAGON_LOCAL_VOICE_HOME:-$HOME/dragon-local-voice-v1}"
+V1_ENV="$V1_HOME/.env"
+V2_HOME="${DRAGON_LOCAL_VOICE_V2_HOME:-$HOME/dragon-local-voice-v2}"
+URL="${DRAGON_LOCAL_VOICE_V2_URL:-http://127.0.0.1:8124}"
+OUT="$V2_HOME/seven-voice-proof"
+
+if [ ! -s "$V1_ENV" ]; then
+  echo 'VOICE_TOKEN_ENV=MISS'
+  exit 4
+fi
+set -a
+# shellcheck disable=SC1090
+source "$V1_ENV"
+set +a
+
+mkdir -p "$OUT"
+rm -f "$OUT"/*.wav "$OUT"/*.headers "$OUT"/SHA256SUMS
+
+profiles=(
+  nova_warm
+  dragon_playful
+  dragon_serious
+  dragon_deep
+  whatsapp_natural
+  story_soul
+  night_whisper
+)
+
+for profile in "${profiles[@]}"; do
+  text="Universal Dragon ${profile//_/ } voice is online. This is a local human voice proof."
+  payload="$(python3 - "$text" "$profile" <<'PY'
+import json, sys
+print(json.dumps({
+    "text": sys.argv[1],
+    "profile": sys.argv[2],
+    "context": "chat",
+    "engine": "kokoro",
+    "intensity": 0.68,
+}))
+PY
+)"
+  curl --silent --show-error --fail --max-time 900 \
+    -D "$OUT/$profile.headers" \
+    -H "Authorization: Bearer $DRAGON_VOICE_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" \
+    "${URL%/}/v2/speak" \
+    -o "$OUT/$profile.wav"
+  test -s "$OUT/$profile.wav"
+  file "$OUT/$profile.wav" | grep -qi 'wave audio'
+  grep -qi '^X-Dragon-Voice-Engine: kokoro' "$OUT/$profile.headers"
+  echo "VOICE_${profile^^}=PASS"
+done
+
+(
+  cd "$OUT"
+  sha256sum ./*.wav >SHA256SUMS
+)
+
+test "$(find "$OUT" -maxdepth 1 -name '*.wav' -type f | wc -l)" -eq 7
+echo "SEVEN_VOICE_PROOF_DIR=$OUT"
+echo 'SEVEN_DISTINCT_VOICE_FILES=PASS'
+echo 'DRAGON_HUMAN_VOICE_SET_V2=PASS'

--- a/local-voice/v2/requirements-nano.txt
+++ b/local-voice/v2/requirements-nano.txt
@@ -1,0 +1,1 @@
+chatterbox-tts==0.1.7

--- a/local-voice/v2/requirements-v2.txt
+++ b/local-voice/v2/requirements-v2.txt
@@ -2,7 +2,6 @@ fastapi>=0.115,<1
 uvicorn[standard]>=0.34,<1
 pydantic>=2.10,<3
 numpy>=2,<3
-torch>=2.6,<3
 transformers>=4.46,<5
 huggingface-hub>=0.28,<1
 loguru>=0.7,<1
@@ -11,5 +10,8 @@ regex>=2024.11
 phonemizer-fork>=3.3,<4
 espeakng-loader>=0.2,<1
 
-# Kokoro/Misaki Python 3.13 source pins are installed separately with --no-deps
-# by install-v2-pi5.sh so the heavy misaki[en] spaCy chain is never pulled.
+# torch is intentionally installed separately from the official PyTorch CPU
+# wheel index by install-v2-pi5.sh. Do not add plain `torch` here: current
+# Linux aarch64 PyPI wheels may pull NVIDIA/CUDA packages that Pi5 cannot use.
+# Kokoro/Misaki Python 3.13 source pins are also installed separately with
+# --no-deps so the heavy misaki[en] spaCy chain is never pulled.

--- a/local-voice/v2/requirements-v2.txt
+++ b/local-voice/v2/requirements-v2.txt
@@ -1,0 +1,5 @@
+fastapi>=0.115,<1
+uvicorn[standard]>=0.34,<1
+pydantic>=2.10,<3
+kokoro==0.9.4
+numpy>=2,<3

--- a/local-voice/v2/requirements-v2.txt
+++ b/local-voice/v2/requirements-v2.txt
@@ -1,5 +1,9 @@
 fastapi>=0.115,<1
 uvicorn[standard]>=0.34,<1
 pydantic>=2.10,<3
-kokoro==0.9.4
+# PyPI kokoro/misaki 0.9.4 metadata rejects Python 3.13.
+# These exact upstream commits only relax requires-python to <3.14 and were
+# explicitly merged/tested by upstream to enable Python 3.13.
+misaki[en] @ https://github.com/hexgrad/misaki/archive/fba1236595f2d2bf21d414ba6e57d25256afada3.tar.gz
+kokoro @ https://github.com/hexgrad/kokoro/archive/dfb907a02bba8152ca444717ca5d78747ccb4bec.tar.gz
 numpy>=2,<3

--- a/local-voice/v2/requirements-v2.txt
+++ b/local-voice/v2/requirements-v2.txt
@@ -1,9 +1,15 @@
 fastapi>=0.115,<1
 uvicorn[standard]>=0.34,<1
 pydantic>=2.10,<3
-# PyPI kokoro/misaki 0.9.4 metadata rejects Python 3.13.
-# These exact upstream commits only relax requires-python to <3.14 and were
-# explicitly merged/tested by upstream to enable Python 3.13.
-misaki[en] @ https://github.com/hexgrad/misaki/archive/fba1236595f2d2bf21d414ba6e57d25256afada3.tar.gz
-kokoro @ https://github.com/hexgrad/kokoro/archive/dfb907a02bba8152ca444717ca5d78747ccb4bec.tar.gz
 numpy>=2,<3
+torch>=2.6,<3
+transformers>=4.46,<5
+huggingface-hub>=0.28,<1
+loguru>=0.7,<1
+addict>=2.4,<3
+regex>=2024.11
+phonemizer-fork>=3.3,<4
+espeakng-loader>=0.2,<1
+
+# Kokoro/Misaki Python 3.13 source pins are installed separately with --no-deps
+# by install-v2-pi5.sh so the heavy misaki[en] spaCy chain is never pulled.

--- a/local-voice/v2/verify_v2_static.py
+++ b/local-voice/v2/verify_v2_static.py
@@ -32,6 +32,14 @@ expected = {
 }
 require(set(profiles["profiles"]) == expected, "SEVEN_HUMAN_VOICE_IDENTITIES")
 
+requirements = (ROOT / "requirements-v2.txt").read_text(encoding="utf-8")
+require(
+    "dfb907a02bba8152ca444717ca5d78747ccb4bec" in requirements
+    and "fba1236595f2d2bf21d414ba6e57d25256afada3" in requirements,
+    "PYTHON313_UPSTREAM_SOURCE_PINS",
+)
+require("kokoro==0.9.4" not in requirements, "PYTHON313_PYPI_BLOCKER_REMOVED")
+
 clean = sanitize_spoken_text("Hello <analysis>private thought</analysis> [laugh] human")
 require("private thought" not in clean and "[laugh]" not in clean and clean == "Hello human", "VOICE_SOUL_V2_SANITIZER")
 

--- a/local-voice/v2/verify_v2_static.py
+++ b/local-voice/v2/verify_v2_static.py
@@ -32,17 +32,22 @@ expected = {
 }
 require(set(profiles["profiles"]) == expected, "SEVEN_HUMAN_VOICE_IDENTITIES")
 
-requirements = (ROOT / "requirements-v2.txt").read_text(encoding="utf-8")
+requirements_text = (ROOT / "requirements-v2.txt").read_text(encoding="utf-8")
+active_requirements = "\n".join(
+    line.strip()
+    for line in requirements_text.splitlines()
+    if line.strip() and not line.lstrip().startswith("#")
+)
 installer = (ROOT / "install-v2-pi5.sh").read_text(encoding="utf-8")
-require("misaki[en]" not in requirements, "SPACY_EXTRA_REMOVED")
-require("spacy" not in requirements.lower(), "SPACY_RUNTIME_DEPENDENCY_NO")
-require("--no-deps" in installer, "UPSTREAM_NO_DEPS_INSTALL=PASS")
+require("misaki[en]" not in active_requirements, "SPACY_EXTRA_REMOVED")
+require("spacy" not in active_requirements.lower(), "SPACY_RUNTIME_DEPENDENCY_NO")
+require("--no-deps" in installer, "UPSTREAM_NO_DEPS_INSTALL")
 require(
     "dfb907a02bba8152ca444717ca5d78747ccb4bec" in installer
     and "fba1236595f2d2bf21d414ba6e57d25256afada3" in installer,
     "PYTHON313_UPSTREAM_SOURCE_PINS",
 )
-require("kokoro==0.9.4" not in requirements, "PYTHON313_PYPI_BLOCKER_REMOVED")
+require("kokoro==0.9.4" not in active_requirements, "PYTHON313_PYPI_BLOCKER_REMOVED")
 
 lite = (ROOT / "kokoro_pi5_lite.py").read_text(encoding="utf-8")
 require("EspeakFallback" in lite and "KModel" in lite, "KOKORO_ESPEAK_LITE_FRONTEND")

--- a/local-voice/v2/verify_v2_static.py
+++ b/local-voice/v2/verify_v2_static.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from voice_soul_v2 import plan_voice, sanitize_spoken_text
+
+ROOT = Path(__file__).resolve().parent
+
+
+def require(condition: bool, marker: str) -> None:
+    """Fail the proof immediately when a required contract is false."""
+    if not condition:
+        raise SystemExit(f"{marker}=FAIL")
+    print(f"{marker}=PASS")
+
+
+for filename in ("voice_soul_v2.py", "dragon_voice_v2_server.py"):
+    source = (ROOT / filename).read_text(encoding="utf-8")
+    compile(source, str(ROOT / filename), "exec")
+print("HUMAN_VOICE_V2_PYTHON_SYNTAX=PASS")
+
+profiles = json.loads((ROOT / "profiles-v2.json").read_text(encoding="utf-8"))
+expected = {
+    "nova_warm",
+    "dragon_playful",
+    "dragon_serious",
+    "dragon_deep",
+    "whatsapp_natural",
+    "story_soul",
+    "night_whisper",
+}
+require(set(profiles["profiles"]) == expected, "SEVEN_HUMAN_VOICE_IDENTITIES")
+
+clean = sanitize_spoken_text("Hello <analysis>private thought</analysis> [laugh] human")
+require("private thought" not in clean and "[laugh]" not in clean and clean == "Hello human", "VOICE_SOUL_V2_SANITIZER")
+
+whatsapp = plan_voice("Bro, I will reply now.", context="whatsapp")
+require(whatsapp["profile"] == "whatsapp_natural", "WHATSAPP_NATURAL_ROUTING")
+
+laugh = plan_voice("That is hilarious haha", mood="laugh", context="chat")
+require(laugh["profile"] == "dragon_playful", "PLAYFUL_LAUGH_ROUTING")
+require(laugh["nano"]["native_reaction_tag"] is True and "[laugh]" in laugh["nano"]["text"], "NANO_NATIVE_LAUGH_PLAN")
+
+serious = plan_voice("Critical warning. Stop now.", context="alert")
+require(serious["profile"] == "dragon_serious", "SERIOUS_ALERT_ROUTING")
+
+deep = plan_voice("Systems online.", context="robot")
+require(deep["profile"] == "dragon_deep", "ROBOT_DEEP_ROUTING")
+
+night = plan_voice("Speak softly tonight.", context="night")
+require(night["profile"] == "night_whisper", "WHISPER_ROUTING")
+
+truth = whatsapp["truth"]
+require(truth["paid_api_required"] is False, "PAID_API_REQUIRED_NO")
+require(truth["v3d_tts_inference_claimed"] is False, "V3D_TTS_CLAIM_NO")
+require(truth["exact_real_person_voice_claimed"] is False, "REAL_PERSON_CLONE_CLAIM_NO")
+
+server = (ROOT / "dragon_voice_v2_server.py").read_text(encoding="utf-8")
+require("hmac.compare_digest" in server and "if not ACCESS_TOKEN:\n        return False" in server, "V2_FAIL_CLOSED_AUTH")
+require("127.0.0.1:8123" in server, "PROVEN_V1_FALLBACK_WIRED")
+
+print("HUMAN_VOICE_SOUL_V2_STATIC_PROOF=PASS")

--- a/local-voice/v2/verify_v2_static.py
+++ b/local-voice/v2/verify_v2_static.py
@@ -15,7 +15,7 @@ def require(condition: bool, marker: str) -> None:
     print(f"{marker}=PASS")
 
 
-for filename in ("voice_soul_v2.py", "dragon_voice_v2_server.py"):
+for filename in ("voice_soul_v2.py", "dragon_voice_v2_server.py", "kokoro_pi5_lite.py"):
     source = (ROOT / filename).read_text(encoding="utf-8")
     compile(source, str(ROOT / filename), "exec")
 print("HUMAN_VOICE_V2_PYTHON_SYNTAX=PASS")
@@ -33,12 +33,20 @@ expected = {
 require(set(profiles["profiles"]) == expected, "SEVEN_HUMAN_VOICE_IDENTITIES")
 
 requirements = (ROOT / "requirements-v2.txt").read_text(encoding="utf-8")
+installer = (ROOT / "install-v2-pi5.sh").read_text(encoding="utf-8")
+require("misaki[en]" not in requirements, "SPACY_EXTRA_REMOVED")
+require("spacy" not in requirements.lower(), "SPACY_RUNTIME_DEPENDENCY_NO")
+require("--no-deps" in installer, "UPSTREAM_NO_DEPS_INSTALL=PASS")
 require(
-    "dfb907a02bba8152ca444717ca5d78747ccb4bec" in requirements
-    and "fba1236595f2d2bf21d414ba6e57d25256afada3" in requirements,
+    "dfb907a02bba8152ca444717ca5d78747ccb4bec" in installer
+    and "fba1236595f2d2bf21d414ba6e57d25256afada3" in installer,
     "PYTHON313_UPSTREAM_SOURCE_PINS",
 )
 require("kokoro==0.9.4" not in requirements, "PYTHON313_PYPI_BLOCKER_REMOVED")
+
+lite = (ROOT / "kokoro_pi5_lite.py").read_text(encoding="utf-8")
+require("EspeakFallback" in lite and "KModel" in lite, "KOKORO_ESPEAK_LITE_FRONTEND")
+require("KPipeline" not in lite, "KPIPELINE_SPACY_PATH_BYPASSED")
 
 clean = sanitize_spoken_text("Hello <analysis>private thought</analysis> [laugh] human")
 require("private thought" not in clean and "[laugh]" not in clean and clean == "Hello human", "VOICE_SOUL_V2_SANITIZER")
@@ -67,5 +75,6 @@ require(truth["exact_real_person_voice_claimed"] is False, "REAL_PERSON_CLONE_CL
 server = (ROOT / "dragon_voice_v2_server.py").read_text(encoding="utf-8")
 require("hmac.compare_digest" in server and "if not ACCESS_TOKEN:\n        return False" in server, "V2_FAIL_CLOSED_AUTH")
 require("127.0.0.1:8123" in server, "PROVEN_V1_FALLBACK_WIRED")
+require("espeak-spacy-free" in server, "SPACY_FREE_TRUTH_MARKER")
 
 print("HUMAN_VOICE_SOUL_V2_STATIC_PROOF=PASS")

--- a/local-voice/v2/voice_soul_v2.py
+++ b/local-voice/v2/voice_soul_v2.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+APP_DIR = Path(__file__).resolve().parent
+DEFAULT_PROFILES_PATH = APP_DIR / "profiles-v2.json"
+
+MOODS = {
+    "neutral",
+    "smile",
+    "laugh",
+    "serious",
+    "whisper",
+    "sad",
+    "confident",
+    "curious",
+    "alert",
+}
+CONTEXTS = {"chat", "whatsapp", "wake", "story", "robot", "alert", "night"}
+REACTIONS = {"none", "laugh", "chuckle", "cough", "sigh", "gasp", "breath", "throat_clear"}
+NANO_NATIVE_TAGS = {"laugh": "[laugh]", "chuckle": "[chuckle]", "cough": "[cough]"}
+
+
+def load_profiles(path: Path = DEFAULT_PROFILES_PATH) -> dict[str, Any]:
+    """Load the V2 voice identity contract."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema") != "dragon.voice-soul.profiles.v2":
+        raise RuntimeError("unsupported V2 profile schema")
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict) or len(profiles) != 7:
+        raise RuntimeError("V2 requires exactly seven voice profiles")
+    if data.get("default_profile") not in profiles:
+        raise RuntimeError("V2 default profile missing")
+    return data
+
+
+def sanitize_spoken_text(text: str, limit: int = 1200) -> str:
+    """Remove private-reasoning markup and untrusted audio tags from speech."""
+    value = text
+    value = re.sub(r"<(think|analysis|reasoning)\b[^>]*>[\s\S]*?</\1>", " ", value, flags=re.I)
+    value = re.sub(r"<(think|analysis|reasoning)\b[^>]*>[\s\S]*$", " ", value, flags=re.I)
+    value = re.sub(r"\[[^\]]{1,80}\]", " ", value)
+    value = re.sub(r"\s+", " ", value).strip()
+    return value[:limit].strip()
+
+
+def infer_mood(text: str, context: str) -> str:
+    """Infer a conservative delivery mood from bounded text and context."""
+    lower = text.lower()
+    if context == "alert" or re.search(r"\b(error|danger|warning|critical|stop|urgent)\b", lower):
+        return "alert"
+    if context == "night" or re.search(r"\b(whisper|quiet|softly|sleep|night)\b", lower):
+        return "whisper"
+    if re.search(r"\b(haha|hehe|lol|hilarious|funny)\b", lower):
+        return "laugh"
+    if re.search(r"\b(sad|sorry|miss|hurt|unfortunately)\b", lower):
+        return "sad"
+    if re.search(r"\b(why|how|wonder|curious|really\?)\b", lower):
+        return "curious"
+    if context == "wake" or re.search(r"\b(hey dragon|wake|awaken|resonance)\b", lower):
+        return "smile"
+    if context == "robot":
+        return "confident"
+    return "neutral"
+
+
+def choose_profile(profiles: dict[str, Any], requested: str | None, mood: str, context: str) -> str:
+    """Choose a stable identity while respecting explicit valid requests."""
+    available = profiles["profiles"]
+    if requested and requested in available:
+        return requested
+    if context == "whatsapp":
+        return "whatsapp_natural"
+    if context == "story":
+        return "story_soul"
+    if context == "night" or mood == "whisper":
+        return "night_whisper"
+    if context == "alert" or mood in {"serious", "alert"}:
+        return "dragon_serious"
+    if context == "robot" or mood == "confident":
+        return "dragon_deep"
+    if mood in {"smile", "laugh"}:
+        return "dragon_playful"
+    return profiles["default_profile"]
+
+
+def _reaction_for(mood: str, requested: str | None) -> str:
+    """Resolve a reaction without accepting arbitrary model control tokens."""
+    if requested in REACTIONS:
+        return requested
+    if mood == "laugh":
+        return "laugh"
+    if mood == "smile":
+        return "chuckle"
+    if mood == "sad":
+        return "sigh"
+    if mood == "whisper":
+        return "breath"
+    return "none"
+
+
+def _speed_for(base: float, mood: str, intensity: float) -> float:
+    """Apply bounded pacing adjustments for natural delivery."""
+    intensity = max(0.0, min(1.0, intensity))
+    factor = {
+        "neutral": 1.0,
+        "smile": 1.02,
+        "laugh": 1.04,
+        "serious": 0.94,
+        "whisper": 0.88,
+        "sad": 0.90,
+        "confident": 0.96,
+        "curious": 0.99,
+        "alert": 1.02,
+    }[mood]
+    blended = 1.0 + (factor - 1.0) * (0.55 + 0.45 * intensity)
+    return round(max(0.72, min(1.18, base * blended)), 3)
+
+
+def _nano_text(text: str, reaction: str) -> tuple[str, bool]:
+    """Render only paralinguistic tags documented by the upstream Nano/Turbo family."""
+    tag = NANO_NATIVE_TAGS.get(reaction)
+    if not tag:
+        return text, False
+    if reaction == "laugh":
+        return f"{text} {tag}", True
+    return f"{tag} {text}", True
+
+
+def plan_voice(
+    text: str,
+    *,
+    profile: str | None = None,
+    mood: str | None = None,
+    context: str = "chat",
+    reaction: str | None = None,
+    intensity: float = 0.65,
+    profiles_path: Path = DEFAULT_PROFILES_PATH,
+) -> dict[str, Any]:
+    """Build a provider-independent Human Voice Soul V2 execution plan."""
+    clean = sanitize_spoken_text(text)
+    if not clean:
+        raise ValueError("spoken text is empty after sanitization")
+    if context not in CONTEXTS:
+        context = "chat"
+    resolved_mood = mood if mood in MOODS else infer_mood(clean, context)
+    profiles = load_profiles(profiles_path)
+    profile_id = choose_profile(profiles, profile, resolved_mood, context)
+    identity = profiles["profiles"][profile_id]
+    resolved_reaction = _reaction_for(resolved_mood, reaction)
+    nano_text, nano_native = _nano_text(clean, resolved_reaction)
+
+    # Normal human conversation prioritizes the light multi-voice engine.
+    # Native reaction requests prefer Nano only when the runtime can preserve identity.
+    engine_order = ["nano", "kokoro", "piper"] if nano_native else ["kokoro", "nano", "piper"]
+
+    return {
+        "schema": "dragon.voice-soul.v2",
+        "profile": profile_id,
+        "display_name": identity["display_name"],
+        "persona": identity["persona"],
+        "mood": resolved_mood,
+        "context": context,
+        "reaction": resolved_reaction,
+        "intensity": round(max(0.0, min(1.0, intensity)), 3),
+        "spoken_text": clean,
+        "engine_order": engine_order,
+        "kokoro": {
+            "voice": identity["kokoro_voice"],
+            "speed": _speed_for(float(identity["kokoro_speed"]), resolved_mood, intensity),
+        },
+        "nano": {
+            "text": nano_text,
+            "native_reaction_tag": nano_native,
+            "reference_file": identity["reference_file"],
+        },
+        "piper": {"profile": identity["piper_profile"]},
+        "truth": {
+            "paid_api_required": False,
+            "v3d_tts_inference_claimed": False,
+            "exact_real_person_voice_claimed": False,
+        },
+    }

--- a/local-voice/verify_static.py
+++ b/local-voice/verify_static.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import py_compile
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent
+SERVER = ROOT / "dragon_voice_server.py"
+PROFILES = ROOT / "profiles.json"
+INSTALLER = ROOT / "install-pi5.sh"
+
+py_compile.compile(str(SERVER), doraise=True)
+print("LOCAL_VOICE_PYTHON_SYNTAX=PASS")
+
+data = json.loads(PROFILES.read_text(encoding="utf-8"))
+assert data["schema"] == "dragon.local-voice.profiles.v1"
+assert data["default_profile"] in data["profiles"]
+assert len(data["profiles"]) == 7
+assert len(set(data["profiles"])) == 7
+assert data["default_model"].endswith(".onnx")
+
+required = {
+    "nova_warm",
+    "dragon_playful",
+    "dragon_serious",
+    "dragon_deep",
+    "whatsapp_natural",
+    "story_soul",
+    "night_whisper",
+}
+assert set(data["profiles"]) == required
+
+for name, profile in data["profiles"].items():
+    assert profile["model"].endswith(".onnx"), name
+    for key in ("volume", "length_scale", "noise_scale", "noise_w_scale"):
+        assert isinstance(profile[key], (int, float)), (name, key)
+        assert profile[key] > 0, (name, key)
+
+print("SEVEN_VOICE_PROFILE_CONTRACT=PASS")
+
+installer = INSTALLER.read_text(encoding="utf-8")
+for marker in (
+    "PAID_API_USED=NO",
+    "ELEVENLABS_REQUIRED=NO",
+    "V3D_TTS_INFERENCE_CLAIMED=NO",
+    "DRAGON_LOCAL_VOICE_V1=PASS",
+):
+    assert marker in installer, marker
+
+server = SERVER.read_text(encoding="utf-8")
+for marker in (
+    '"paid_api_required": False',
+    '"v3d_voice_inference_claimed": False',
+    '"cpu-baseline"',
+    "hmac.compare_digest",
+):
+    assert marker in server, marker
+
+print("TRUTH_BOUNDARY=PASS")
+print("SECRET_COMPARISON=PASS")
+print("PAID_PROVIDER_DEPENDENCY=NO")
+print("DRAGON_LOCAL_VOICE_STATIC_PROOF=PASS")
+sys.exit(0)

--- a/room-magic/termux/voice-local-pi5-v2.sh
+++ b/room-magic/termux/voice-local-pi5-v2.sh
@@ -1,0 +1,66 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -Eeuo pipefail
+
+VOICE_URL="${DRAGON_LOCAL_VOICE_V2_URL:-}"
+TOKEN="${DRAGON_LOCAL_VOICE_TOKEN:-}"
+PROFILE="${DRAGON_LOCAL_VOICE_PROFILE:-whatsapp_natural}"
+MOOD="${DRAGON_LOCAL_VOICE_MOOD:-neutral}"
+CONTEXT="${DRAGON_LOCAL_VOICE_CONTEXT:-whatsapp}"
+REACTION="${DRAGON_LOCAL_VOICE_REACTION:-none}"
+ENGINE="${DRAGON_LOCAL_VOICE_ENGINE:-auto}"
+TEXT="${*:-}"
+OUT="${DRAGON_LOCAL_VOICE_OUT:-$HOME/dragon-voice-reply-v2.wav}"
+MAX_TEXT=1200
+
+if [ -z "$VOICE_URL" ]; then
+  echo 'DRAGON_LOCAL_VOICE_V2_URL=MISS'
+  exit 2
+fi
+if [ -z "$TOKEN" ]; then
+  echo 'DRAGON_LOCAL_VOICE_TOKEN=MISS'
+  exit 3
+fi
+if [ -z "$TEXT" ]; then
+  echo 'usage: voice-local-pi5-v2.sh "text to speak"'
+  exit 4
+fi
+if [ "${#TEXT}" -gt "$MAX_TEXT" ]; then
+  echo "VOICE_TEXT_TOO_LONG=${#TEXT}"
+  echo "VOICE_TEXT_MAX=$MAX_TEXT"
+  exit 5
+fi
+
+PAYLOAD="$(python - "$TEXT" "$PROFILE" "$MOOD" "$CONTEXT" "$REACTION" "$ENGINE" <<'PY'
+import json, sys
+print(json.dumps({
+    "text": sys.argv[1],
+    "profile": sys.argv[2],
+    "mood": sys.argv[3],
+    "context": sys.argv[4],
+    "reaction": sys.argv[5],
+    "engine": sys.argv[6],
+    "intensity": 0.68,
+}))
+PY
+)"
+
+HEADERS="${OUT}.headers"
+curl --silent --show-error --fail --max-time 900 \
+  -D "$HEADERS" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "$PAYLOAD" \
+  "${VOICE_URL%/}/v2/speak" \
+  -o "$OUT"
+
+test -s "$OUT"
+echo "VOICE_FILE=$OUT"
+echo "VOICE_PROFILE=$PROFILE"
+echo "VOICE_MOOD=$MOOD"
+echo "VOICE_CONTEXT=$CONTEXT"
+awk -F': ' 'BEGIN{IGNORECASE=1} /^X-Dragon-Voice-Engine:/{gsub(/\r/,"",$2); print "VOICE_ENGINE=" $2}' "$HEADERS"
+echo 'LOCAL_PI5_HUMAN_VOICE_V2_FETCH=PASS'
+
+if command -v termux-media-player >/dev/null 2>&1; then
+  termux-media-player play "$OUT" >/dev/null 2>&1 || true
+fi

--- a/room-magic/termux/voice-local-pi5.sh
+++ b/room-magic/termux/voice-local-pi5.sh
@@ -1,0 +1,43 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -Eeuo pipefail
+
+VOICE_URL="${DRAGON_LOCAL_VOICE_URL:-}"
+TOKEN="${DRAGON_LOCAL_VOICE_TOKEN:-}"
+PROFILE="${DRAGON_LOCAL_VOICE_PROFILE:-whatsapp_natural}"
+TEXT="${*:-}"
+OUT="${DRAGON_LOCAL_VOICE_OUT:-$HOME/dragon-voice-reply.wav}"
+
+if [ -z "$VOICE_URL" ]; then
+  echo 'DRAGON_LOCAL_VOICE_URL=MISS'
+  exit 2
+fi
+if [ -z "$TOKEN" ]; then
+  echo 'DRAGON_LOCAL_VOICE_TOKEN=MISS'
+  exit 3
+fi
+if [ -z "$TEXT" ]; then
+  echo 'usage: voice-local-pi5.sh "text to speak"'
+  exit 4
+fi
+
+PAYLOAD="$(python - "$TEXT" "$PROFILE" <<'PY'
+import json, sys
+print(json.dumps({"text": sys.argv[1], "profile": sys.argv[2], "intensity": 0.65}))
+PY
+)"
+
+curl --silent --show-error --fail \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "$PAYLOAD" \
+  "${VOICE_URL%/}/v1/speak" \
+  -o "$OUT"
+
+test -s "$OUT"
+echo "VOICE_FILE=$OUT"
+echo "VOICE_PROFILE=$PROFILE"
+echo 'LOCAL_PI5_VOICE_FETCH=PASS'
+
+if command -v termux-media-player >/dev/null 2>&1; then
+  termux-media-player play "$OUT" >/dev/null 2>&1 || true
+fi

--- a/room-magic/termux/voice-local-pi5.sh
+++ b/room-magic/termux/voice-local-pi5.sh
@@ -6,6 +6,7 @@ TOKEN="${DRAGON_LOCAL_VOICE_TOKEN:-}"
 PROFILE="${DRAGON_LOCAL_VOICE_PROFILE:-whatsapp_natural}"
 TEXT="${*:-}"
 OUT="${DRAGON_LOCAL_VOICE_OUT:-$HOME/dragon-voice-reply.wav}"
+MAX_TEXT=1200
 
 if [ -z "$VOICE_URL" ]; then
   echo 'DRAGON_LOCAL_VOICE_URL=MISS'
@@ -18,6 +19,11 @@ fi
 if [ -z "$TEXT" ]; then
   echo 'usage: voice-local-pi5.sh "text to speak"'
   exit 4
+fi
+if [ "${#TEXT}" -gt "$MAX_TEXT" ]; then
+  echo "VOICE_TEXT_TOO_LONG=${#TEXT}"
+  echo "VOICE_TEXT_MAX=$MAX_TEXT"
+  exit 5
 fi
 
 PAYLOAD="$(python - "$TEXT" "$PROFILE" <<'PY'

--- a/src/voice/localPi.ts
+++ b/src/voice/localPi.ts
@@ -1,0 +1,79 @@
+export type LocalDragonVoiceProfile =
+  | 'nova_warm'
+  | 'dragon_playful'
+  | 'dragon_serious'
+  | 'dragon_deep'
+  | 'whatsapp_natural'
+  | 'story_soul'
+  | 'night_whisper';
+
+export interface LocalDragonVoiceRequest {
+  text: string;
+  profile?: LocalDragonVoiceProfile;
+  intensity?: number;
+}
+
+export interface LocalDragonVoiceResult {
+  audio: Buffer;
+  contentType: string;
+  profile: string;
+  model: string;
+  modelFallback: boolean;
+  inferenceMs: number | null;
+}
+
+export function localDragonVoiceConfigured(): boolean {
+  return Boolean(process.env.DRAGON_LOCAL_VOICE_URL && process.env.DRAGON_LOCAL_VOICE_TOKEN);
+}
+
+export async function generateLocalDragonVoice(
+  request: LocalDragonVoiceRequest,
+): Promise<LocalDragonVoiceResult> {
+  const baseUrl = (process.env.DRAGON_LOCAL_VOICE_URL || '').replace(/\/$/, '');
+  const token = process.env.DRAGON_LOCAL_VOICE_TOKEN || '';
+
+  if (!baseUrl || !token) {
+    throw new Error('local_voice_not_configured');
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 45_000);
+
+  try {
+    const response = await fetch(`${baseUrl}/v1/speak`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'audio/wav',
+      },
+      body: JSON.stringify({
+        text: request.text.slice(0, 1200),
+        profile: request.profile ?? 'nova_warm',
+        intensity: Math.max(0, Math.min(1, request.intensity ?? 0.65)),
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const detail = (await response.text()).slice(0, 240);
+      throw new Error(`local_voice_http_${response.status}:${detail}`);
+    }
+
+    const inferenceHeader = response.headers.get('x-dragon-inference-ms');
+    const inferenceMs = inferenceHeader && /^\d+$/.test(inferenceHeader)
+      ? Number(inferenceHeader)
+      : null;
+
+    return {
+      audio: Buffer.from(await response.arrayBuffer()),
+      contentType: response.headers.get('content-type') || 'audio/wav',
+      profile: response.headers.get('x-dragon-voice-profile') || request.profile || 'nova_warm',
+      model: response.headers.get('x-dragon-voice-model') || 'unknown',
+      modelFallback: response.headers.get('x-dragon-model-fallback') === 'yes',
+      inferenceMs,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## Goal
Build a truthful, local-first voice stack for Pi5 that can serve NOVA, EVE, Novakutty, Room Magic, WhatsApp voice replies, phone clients, and future robot adapters without a paid speech dependency.

## V1: proven on the real Raspberry Pi 5
- Piper + ONNX Runtime local service
- 7 stable Dragon profile slots with explicit fallback markers
- fail-closed bearer-token protection
- user systemd service on loopback
- Huawei/Termux client
- no paid API / no ElevenLabs requirement

Real Pi5 runtime proof completed:
- `LOCAL_VOICE_HEALTH=PASS`
- `LOCAL_WAV_GENERATION=PASS`
- `PAID_API_USED=NO`
- `ELEVENLABS_REQUIRED=NO`
- `DRAGON_LOCAL_VOICE_V1=PASS`
- `PI5_DRAGON_VOICE_INSTALL=PASS`
- `proof.wav`: RIFF PCM, 16-bit mono, 22050 Hz, 113K
- service active on `127.0.0.1:8123`

## V2: Human Voice Soul
Adds the human-like orchestration layer while keeping V1 as the fail-safe:
- 7 original voice identities: NOVA Warm, Dragon Playful, Dragon Serious, Dragon Deep, WhatsApp Natural, Story Soul, Night Whisper
- moods: neutral, smile, laugh, serious, whisper, sad, confident, curious, alert
- contexts: chat, WhatsApp, wake, story, robot, alert, night
- provider-independent planner with reasoning/audio-tag sanitization
- Kokoro 82M multi-voice CPU-first natural speech lane
- optional Chatterbox Nano expressive/paralinguistic lane
- Piper V1 fallback
- permissioned local reference-WAV policy for identity-preserving Nano use
- V2 FastAPI router on loopback
- V2 Huawei/Termux client
- seven-identity audio proof script
- Pi5 V2 installer and separate bounded Nano installer

## Security fixes after CodeRabbit V1 review
All six original review threads were addressed:
- missing bearer token now fails closed
- whitespace-only speech is rejected
- bootstrap model cannot diverge from configured default
- venv interpreter path is quoted
- Termux client enforces 1200-character boundary
- CI scans the Node adapter, Dragon bearer token, tracked `.env`, paid-provider secrets, model weights, and local reference WAVs

## CI / artifact proof
Current head `e1b4fc57e111ccc4f732527e411c822a5c843e32`:
- V1 static contract PASS
- Human Voice Soul V2 static contract PASS
- shell syntax PASS
- secret guard PASS
- no committed voice weights/reference audio PASS
- portable V2 checksum-path proof PASS
- `Dragon Local Voice V1 + Human Voice Soul V2` workflow SUCCESS
- fresh `dragon-local-voice-v2-handoff` artifact produced and locally checksum/re-extraction verified

## Truth boundary
- paid API required: NO
- ElevenLabs required: NO
- V1 inference: proven CPU/ONNX Runtime
- Pi5 V3D TTS inference: NOT claimed
- exact real-person/actor cloning: NOT claimed
- Kokoro V2 real Pi5 audio proof: next runtime gate
- Chatterbox Nano Pi5 speed/quality: benchmark before any real-time claim

CodeRabbit's original V1 findings are resolved. A new full V2 review request is currently rate-limited by CodeRabbit; CI and deterministic static proof remain green.

Base: Dragon Voice Soul + Room Magic V1 head.